### PR TITLE
adding dependency config and idea configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /build/
-/.gradle/
+.gradle/
+out/
+*.iml
+*.ipr
+*.iws
+

--- a/README.md
+++ b/README.md
@@ -25,6 +25,23 @@ None
 
 ### Extensions Provided
 
-None
+**Dependencies**
 
+```groovy
+dependencies {
+  spinnaker.group("bootWeb")
+  compile spinnaker.dependency("bootActuator")
+}
+```
 
+spinnaker#group will resolve a group of dependencies as defined in src/main/resources/dependencies.yml
+spinnaker#dependency will resolve a specific named dependency as defined in src/main/resources/dependencies.yml
+
+**IDEA Config**
+
+```groovy
+ideaConfig {
+  mainClassName = 'com.netflix.spinnaker.myApp.Main'
+  codeStyleXml = file('gradle/codeStyle.xml')
+}
+```

--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 buildscript {
-    repositories { jcenter() }
-    dependencies { classpath 'com.netflix.nebula:nebula-plugin-plugin:1.9.11' }
+  repositories { jcenter() }
+  dependencies { classpath 'com.netflix.nebula:nebula-plugin-plugin:1.9.11' }
 }
 
 group = 'com.netflix.spinnaker'
 description 'Build conventions for spinnaker Gradle projects'
 apply plugin: 'nebula-plugin'
+apply plugin: 'idea'
 
 bintray {
   pkg {
@@ -33,5 +34,7 @@ bintray {
 dependencies {
   compile 'com.netflix.nebula:nebula-plugin-plugin:1.9.11'
   compile 'com.netflix.nebula:nebula-project-plugin:1.9.6'
+  compile 'org.yaml:snakeyaml:1.13'
+  testCompile "org.spockframework:spock-core:0.7-groovy-1.8"
 }
 

--- a/gradle/m2-init.gradle
+++ b/gradle/m2-init.gradle
@@ -1,14 +1,14 @@
 allprojects {
-    buildscript {
-        repositories {
-            mavenLocal()
-        }
-        configurations.all {
-            resolutionStrategy.cacheChangingModulesFor 0, 'hours'
-        }
-    }
-
+  buildscript {
     repositories {
-        mavenLocal()
+      mavenLocal()
     }
+    configurations.all {
+      resolutionStrategy.cacheChangingModulesFor 0, 'hours'
+    }
+  }
+
+  repositories {
+    mavenLocal()
+  }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 08 16:05:14 PST 2014
+#Thu Jun 19 15:41:10 PDT 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-all.zip

--- a/src/main/groovy/com/netflix/spinnaker/SpinnakerDependencies.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/SpinnakerDependencies.groovy
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker
+
+import groovy.text.SimpleTemplateEngine
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.yaml.snakeyaml.Yaml
+
+@SuppressWarnings("GroovyMissingReturnStatement")
+class SpinnakerDependencies {
+  private final Map config
+  private final Project project
+  private final SimpleTemplateEngine templateEngine = new SimpleTemplateEngine()
+
+  SpinnakerDependencies(Project project) {
+    this.project = project
+    def deps = getClass().getResourceAsStream("/dependencies.yml").text
+    def yaml = new Yaml()
+    config = (Map) yaml.load(deps)
+  }
+
+  Dependency dependency(String module) {
+    if (config.dependencies.containsKey(module)) {
+      return project.dependencies.create(templateEngine.createTemplate(config.dependencies[module] as String).make(config).toString())
+    }
+  }
+
+  void group(String name) {
+    if (config.groups.containsKey(name)) {
+      def $project = project
+      def group = config.groups[name]
+      group.each { String scope, List<String> dependencies ->
+        for (dep in dependencies) {
+          def dependency = dependency(dep)
+          if (dependency) {
+            $project.dependencies.add(scope, dependency)
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/groovy/com/netflix/spinnaker/SpinnakerProjectPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/SpinnakerProjectPlugin.groovy
@@ -15,116 +15,257 @@
  */
 package com.netflix.spinnaker
 
-import org.gradle.api.Action
-import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Plugin
-import org.gradle.api.Project
-import org.gradle.api.XmlProvider
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.GradleBuild
-import org.gradle.plugins.ide.idea.IdeaPlugin
+import com.jfrog.bintray.gradle.BintrayExtension
+import com.netflix.spinnaker.internal.IdeaConfig
+import groovy.util.logging.Log4j
 import nebula.plugin.plugin.NebulaBintrayPublishingPlugin
 import nebula.plugin.plugin.NebulaOJOPublishingPlugin
 import nebula.plugin.publishing.maven.NebulaBaseMavenPublishingPlugin
 import nebula.plugin.responsible.NebulaResponsiblePlugin
-import com.jfrog.bintray.gradle.BintrayExtension
-import release.GitReleasePluginConvention
-import release.ReleasePlugin
-import release.ReleasePluginConvention
+import org.gradle.api.*
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.GradleBuild
+import org.gradle.plugins.ide.api.XmlFileContentMerger
+import org.gradle.plugins.ide.idea.IdeaPlugin
+import release.*
 
-
+@Log4j
 class SpinnakerProjectPlugin implements Plugin<Project> {
-    @Override
-    void apply(Project project) {
-        project.status = project.version.toString().endsWith('-SNAPSHOT')?'integration':'release'
-        project.plugins.apply(NebulaResponsiblePlugin)
+  private String defaultCodeStyleXml
 
-        addStandardRepos(project)
-        addProvidedScope(project)
-        configureBintray(project)
-        tweakGeneratedPom(project)
-        configureSnapshot(project)
-        configureRelease(project)
-    }
+  @Override
+  void apply(Project project) {
+    defaultCodeStyleXml = getClass().getResourceAsStream("/defaultCodeStyle.xml").text
 
-    void addStandardRepos(Project project) {
-        project.repositories.jcenter()
-        project.repositories.maven {
-            name 'Bintray spinnaker repo'
-            url 'http://dl.bintray.com/spinnaker/spinnaker'
+    project.status = project.version.toString().endsWith('-SNAPSHOT') ? 'integration' : 'release'
+    project.plugins.apply(NebulaResponsiblePlugin)
+    project.extensions.create("spinnaker", SpinnakerDependencies, project)
+
+    addStandardRepos(project)
+    addProvidedScope(project)
+    configureBintray(project)
+    tweakGeneratedPom(project)
+    configureSnapshot(project)
+    configureRelease(project)
+
+    project.configure(project) {
+      def ideaConfig = project.extensions.create("ideaConfig", IdeaConfig)
+
+      afterEvaluate {
+        IdeaPlugin ideaPlugin = project == project.rootProject ? project.getPlugins().findPlugin(IdeaPlugin) : project.rootProject.getPlugins().findPlugin(IdeaPlugin)
+        if (ideaPlugin && ideaPlugin.model) {
+          if (ideaConfig.mainClassName) {
+            def springloadedJvmArgs = getSpringloadedJvmArgs(project)
+            applyWorkspaceConfig(project.name, project.projectDir.canonicalPath, springloadedJvmArgs,
+                ideaConfig.mainClassName, ideaPlugin.model.workspace.iws)
+          }
+          if (project == project.rootProject) {
+            applyProjectConfig(ideaConfig, ideaPlugin.model.project.ipr)
+          }
+          ideaPlugin.model.project.jdkName = project.sourceCompatibility
+          ideaPlugin.model.project.languageLevel = project.sourceCompatibility
         }
+      }
     }
+  }
 
-    void addProvidedScope(Project project) {
-        project.plugins.apply(JavaPlugin)
-        project.plugins.apply(IdeaPlugin)
-
-        def provided = project.configurations.maybeCreate('provided')
-        project.sourceSets.main.compileClasspath += provided
-        project.idea.module.scopes.COMPILE.plus += provided
+  void addStandardRepos(Project project) {
+    project.repositories.jcenter()
+    project.repositories.maven {
+      name 'Bintray spinnaker repo'
+      url 'http://dl.bintray.com/spinnaker/spinnaker'
     }
+  }
 
-    void configureBintray(Project project) {
-        project.plugins.apply(NebulaBintrayPublishingPlugin)
-        project.plugins.apply(NebulaOJOPublishingPlugin)
+  static void addProvidedScope(Project project) {
+    project.plugins.apply(JavaPlugin)
+    project.plugins.apply(IdeaPlugin)
 
-        BintrayExtension bintray = project.extensions.getByType(BintrayExtension)
-        bintray.pkg.userOrg = 'spinnaker'
-        bintray.pkg.repo = 'spinnaker'
-        bintray.pkg.labels = ['spinnaker', 'groovy', 'Netflix']
-        project.tasks.publish.dependsOn('bintrayUpload')        
-    }
+    def provided = project.configurations.maybeCreate('provided')
+    project.sourceSets.main.compileClasspath += provided
+    project.idea.module.scopes.COMPILE.plus += provided
+  }
 
-    void tweakGeneratedPom(Project project) {
-        String repoName = project.name
-        project.plugins.withType(NebulaBaseMavenPublishingPlugin) { basePlugin ->
-            basePlugin.withMavenPublication { MavenPublication t ->
-                t.pom.withXml(new Action<XmlProvider>() {
-                    @Override
-                    void execute(XmlProvider x) {
-                        def root = x.asNode()
-                        root.appendNode('url', "https://github.com/spinnaker/${repoName}")
-                        root.appendNode('scm').replaceNode {
-                            scm {
-                                url "scm:git://github.com/spinnaker/${repoName}.git"
-                                connection "scm:git://github.com/spinnaker/${repoName}.git"
-                            }
-                        }
-                    }
-                })
+  static void configureBintray(Project project) {
+    project.plugins.apply(NebulaBintrayPublishingPlugin)
+    project.plugins.apply(NebulaOJOPublishingPlugin)
+
+    BintrayExtension bintray = project.extensions.getByType(BintrayExtension)
+    bintray.pkg.userOrg = 'spinnaker'
+    bintray.pkg.repo = 'spinnaker'
+    bintray.pkg.labels = ['spinnaker', 'groovy', 'Netflix']
+    project.tasks.publish.dependsOn('bintrayUpload')
+  }
+
+  void tweakGeneratedPom(Project project) {
+    String repoName = project.name
+    project.plugins.withType(NebulaBaseMavenPublishingPlugin) { basePlugin ->
+      basePlugin.withMavenPublication { MavenPublication t ->
+        t.pom.withXml(new Action<XmlProvider>() {
+          @Override
+          void execute(XmlProvider x) {
+            def root = x.asNode()
+            root.appendNode('url', "https://github.com/spinnaker/${repoName}")
+            root.appendNode('scm').replaceNode {
+              scm {
+                url "scm:git://github.com/spinnaker/${repoName}.git"
+                connection "scm:git://github.com/spinnaker/${repoName}.git"
+              }
             }
-        }
+          }
+        })
+      }
+    }
+  }
+
+  static void configureSnapshot(Project project) {
+    project.tasks.matching { it.name == 'artifactoryPublish' }.all {
+      project.tasks.create('snapshot').dependsOn(it)
+    }
+  }
+
+  void configureRelease(Project project) {
+    // Release, to be replaced by our own in the future.
+    project.rootProject.plugins.apply(ReleasePlugin)
+    project.rootProject.ext.'gradle.release.useAutomaticVersion' = "true"
+
+    ReleasePluginConvention releaseConvention = project.rootProject.convention.getPlugin(ReleasePluginConvention)
+    releaseConvention.failOnUnversionedFiles = false
+    releaseConvention.failOnCommitNeeded = false
+
+    // We routinely release from different branches, which aren't master
+    def gitReleaseConvention = (GitReleasePluginConvention) releaseConvention.git
+    gitReleaseConvention.requireBranch = null
+    gitReleaseConvention.pushToCurrentBranch = true
+
+    try {
+      def spawnBintrayUpload = project.rootProject.task('spawnBintrayUpload', description: 'Create GradleBuild to run BintrayUpload to use a new version', group: 'Release', type: GradleBuild) {
+        startParameter = project.rootProject.getGradle().startParameter.newInstance()
+        tasks = ['bintrayUpload']
+      }
+      project.rootProject.tasks.createReleaseTag.dependsOn spawnBintrayUpload
+    } catch (InvalidUserDataException iude) {
+      //task already created, ignore
+    }
+  }
+
+  static void applyWorkspaceConfig(String projectName, String projectDir, String springLoadedJvmArgs, String appClassName, XmlFileContentMerger iws) {
+    iws.withXml { provider ->
+      def node = provider.asNode()
+      def runManagerConfig = node['component'].find { it.'@name' == 'RunManager' } as Node
+      if (!runManagerConfig) {
+        runManagerConfig = node.appendNode('component', [name: 'RunManager'])
+      }
+
+      runManagerConfig.append(new XmlParser().parseText("""
+            <configuration default="false" name="Run ${projectName}" type="Application" factoryName="Application">
+              <extension name="coverage" enabled="false" merge="false" />
+              <option name="MAIN_CLASS_NAME" value="${appClassName}" />
+              <option name="VM_PARAMETERS" value="${springLoadedJvmArgs ? '&quot;' + springLoadedJvmArgs + '&quot; &quot;-noverify&quot;' : ''}" />
+              <option name="PROGRAM_PARAMETERS" value="" />
+              <option name="WORKING_DIRECTORY" value="${projectDir}" />
+              <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="false" />
+              <option name="ALTERNATIVE_JRE_PATH" value="" />
+              <option name="ENABLE_SWING_INSPECTOR" value="false" />
+              <option name="ENV_VARIABLES" />
+              <option name="PASS_PARENT_ENVS" value="true" />
+              <module name="${projectName}" />
+              <envs />
+              <RunnerSettings RunnerId="Debug">
+                <option name="DEBUG_PORT" value="63810" />
+                <option name="TRANSPORT" value="0" />
+                <option name="LOCAL" value="true" />
+              </RunnerSettings>
+              <RunnerSettings RunnerId="Run" />
+              <ConfigurationWrapper RunnerId="Debug" />
+              <ConfigurationWrapper RunnerId="Run" />
+              <method />
+            </configuration>
+        """))
+
+    }
+  }
+
+  void applyProjectConfig(IdeaConfig ideaConfig, XmlFileContentMerger ipr) {
+    String codeStyleXmlTxt
+    if (ideaConfig.codeStyleXml) {
+      codeStyleXmlTxt = ideaConfig.codeStyleXml.text
+    } else {
+      log.warn "No codestyle XML file found! Applying default codestyle rules..."
+      codeStyleXmlTxt = defaultCodeStyleXml
+    }
+    ipr.withXml { provider ->
+      def node = provider.asNode()
+      node.component.find { it.'@name' == 'VcsDirectoryMappings' }?.mapping[0].'@vcs' = 'Git'
+
+      if (ideaConfig.codeStyleXml) {
+        node.append(new XmlParser().parseText(codeStyleXmlTxt))
+      }
+
+      def copyrightManager = node.component.find { it.'@name' == 'CopyrightManager' }
+      copyrightManager.@default = "ASL2"
+      def aslCopyright = copyrightManager.copyright.find { it.option.find { it.@name == "myName" }?.@value == "ASL2" }
+      if (aslCopyright == null) {
+        copyrightManager.append(new XmlParser().parseText("""
+            <copyright>
+              <option name="notice" value="Copyright \$today.year Netflix, Inc.&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;   http://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License." />
+              <option name="keyword" value="Copyright" />
+              <option name="allowReplaceKeyword" value="" />
+              <option name="myName" value="ASL2" />
+              <option name="myLocal" value="true" />
+            </copyright>
+          """))
+      }
     }
 
-    void configureSnapshot(Project project) {
-        project.tasks.matching { it.name == 'artifactoryPublish' }.all {
-            project.tasks.create('snapshot').dependsOn(it)
-        }
+  }
+
+  static String getSpringloadedJvmArgs(Project project) {
+    def mainSourceSet = project.convention.getPlugin(JavaPluginConvention).sourceSets.main
+    def jarFile = JarFinder.find("org.springsource.loaded.SpringLoaded", mainSourceSet.compileClasspath.files)
+    if (jarFile) {
+      "-javaagent:${jarFile.absolutePath}"
+    } else {
+      ""
+    }
+  }
+
+  static class JarFinder {
+    static File find(String className, Collection<File> classpath) {
+      findJarFile(maybeLoadClass(className, toClassLoader(classpath)))
     }
 
-    void configureRelease(Project project) {
-        // Release, to be replaced by our own in the future.
-        project.rootProject.plugins.apply(ReleasePlugin)
-        project.rootProject.ext.'gradle.release.useAutomaticVersion' = "true"
+    private static File findJarFile(Class<?> targetClass) {
+      if (targetClass) {
+        String absolutePath = targetClass.getResource('/' + targetClass.getName().replace(".", "/") + ".class").path
+        String jarPath = absolutePath.substring("file:".length(), absolutePath.lastIndexOf("!"))
+        new File(jarPath)
+      } else {
+        null
+      }
+    }
 
-        ReleasePluginConvention releaseConvention = project.rootProject.convention.getPlugin(ReleasePluginConvention)
-        releaseConvention.failOnUnversionedFiles = false
-        releaseConvention.failOnCommitNeeded = false
-
-        // We routinely release from different branches, which aren't master
-        def gitReleaseConvention = (GitReleasePluginConvention) releaseConvention.git
-        gitReleaseConvention.requireBranch = null
-        gitReleaseConvention.pushToCurrentBranch = true
-
+    private static ClassLoader toClassLoader(Collection<File> classpath) {
+      List<URL> urls = new ArrayList<URL>(classpath.size())
+      for (File file in classpath) {
         try {
-            def spawnBintrayUpload = project.rootProject.task('spawnBintrayUpload', description: 'Create GradleBuild to run BintrayUpload to use a new version', group: 'Release', type: GradleBuild) {
-                startParameter = project.rootProject.getGradle().startParameter.newInstance()
-                tasks = ['bintrayUpload']
-            }
-            project.rootProject.tasks.createReleaseTag.dependsOn spawnBintrayUpload
-        } catch (InvalidUserDataException iude) {
-            //task already created, ignore
+          urls.add(file.toURI().toURL())
+        } catch (MalformedURLException ignore) {
         }
+      }
+      new URLClassLoader(urls as URL[])
     }
+
+    private static Class<?> maybeLoadClass(String className, ClassLoader classLoader) {
+      if (classLoader) {
+        try {
+          return classLoader.loadClass(className)
+        } catch (ClassNotFoundException ignore) {
+        }
+      }
+      null
+    }
+  }
 }

--- a/src/main/groovy/com/netflix/spinnaker/internal/IdeaConfig.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/internal/IdeaConfig.groovy
@@ -1,0 +1,6 @@
+package com.netflix.spinnaker.internal
+
+class IdeaConfig {
+  String mainClassName
+  File codeStyleXml
+}

--- a/src/main/resources/defaultCodeStyle.xml
+++ b/src/main/resources/defaultCodeStyle.xml
@@ -1,0 +1,40 @@
+<component name="CodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+        <value>
+            <option name="USE_SAME_INDENTS" value="true"/>
+            <option name="RIGHT_MARGIN" value="200"/>
+            <option name="JD_ALIGN_PARAM_COMMENTS" value="false"/>
+            <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false"/>
+            <option name="JD_P_AT_EMPTY_LINES" value="false"/>
+            <option name="JD_KEEP_EMPTY_PARAMETER" value="false"/>
+            <option name="JD_KEEP_EMPTY_EXCEPTION" value="false"/>
+            <option name="JD_KEEP_EMPTY_RETURN" value="false"/>
+            <option name="WRAP_COMMENTS" value="false"/>
+            <option name="IF_BRACE_FORCE" value="3"/>
+            <option name="DOWHILE_BRACE_FORCE" value="3"/>
+            <option name="WHILE_BRACE_FORCE" value="3"/>
+            <option name="FOR_BRACE_FORCE" value="3"/>
+            <option name="INDENT_SIZE" value="2"/>
+            <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+            <option name="TAB_SIZE" value="2"/>
+            <option name="USE_TAB_CHARACTER" value="false"/>
+            <option name="SMART_TABS" value="false"/>
+            <option name="LABEL_INDENT_SIZE" value="0"/>
+            <option name="LABEL_INDENT_ABSOLUTE" value="false"/>
+            <option name="USE_RELATIVE_INDENTS" value="false"/>
+            <codeStyleSettings language="Groovy">
+                <option name="IF_BRACE_FORCE" value="3"/>
+                <option name="WHILE_BRACE_FORCE" value="3"/>
+                <option name="FOR_BRACE_FORCE" value="3"/>
+                <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
+                <indentOptions>
+                    <option name="INDENT_SIZE" value="2"/>
+                    <option name="CONTINUATION_INDENT_SIZE" value="2"/>
+                    <option name="TAB_SIZE" value="2"/>
+                    <option name="LABEL_INDENT_SIZE" value="2"/>
+                </indentOptions>
+            </codeStyleSettings>
+        </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true"/>
+</component>

--- a/src/main/resources/dependencies.yml
+++ b/src/main/resources/dependencies.yml
@@ -1,0 +1,64 @@
+versions:
+  springBoot: 1.1.1.RELEASE
+  kork: 1.9
+  groovy: 2.3.2
+  astyanax: 1.56.48
+  rxJava: 0.18.3
+  spock: 0.7-groovy-2.0
+  batch: 3.0.0.RC1
+  frigga: 0.13
+  cglib: 3.1
+  amazoncomponents: 0.9.4
+  aws: 1.7.2
+  httpclient: 4.3.3
+  retrofit: 1.5.1
+  guava: 17.0
+  slf4j: 1.7.5
+  okHttp: 1.5.4
+  objenesis: 2.1
+
+groups:
+  bootWeb:
+    compile:
+      - bootActuator
+      - bootWeb
+      - bootDataRest
+  test:
+    testCompile:
+      - bootTest
+      - spock
+      - spockSpring
+      - cglib
+      - objenesis
+  cassandra:
+    compile:
+      - astyanaxCassandra
+      - astyanaxThrift
+  amazon:
+    compile:
+      - amazoncomponents
+      - aws
+
+dependencies:
+  bootActuator: "org.springframework.boot:spring-boot-starter-actuator:${versions.springBoot}"
+  bootWeb: "org.springframework.boot:spring-boot-starter-web:${versions.springBoot}"
+  bootDataRest: "org.springframework.boot:spring-boot-starter-data-rest:${versions.springBoot}"
+  bootTest: "org.springframework.boot:spring-boot-starter-test:${versions.springBoot}"
+  kork: "com.netflix.spinnaker.kork:kork-core:${versions.kork}"
+  groovy: "org.codehaus.groovy:groovy-all:${versions.groovy}:indy"
+  astyanaxCassandra: "com.netflix.astyanax:astyanax-cassandra:${versions.astyanax}"
+  astyanaxThrift: "com.netflix.astyanax:astyanax-thrift:${versions.astyanax}"
+  rxJava: "com.netflix.rxjava:rxjava-core:${versions.rxJava}"
+  spock: "org.spockframework:spock-core:${versions.spock}"
+  spockSpring: "org.spockframework:spock-spring:${versions.spock}"
+  batch: "org.springframework.batch:spring-batch-core:${versions.batch}"
+  frigga: "com.netflix.frigga:frigga:${versions.frigga}"
+  cglib: "cglib:cglib-nodep:${versions.cglib}"
+  amazoncomponents: "com.netflix.amazoncomponents:amazoncomponents:${versions.amazoncomponents}"
+  aws: "com.amazonaws:aws-java-sdk:${versions.aws}"
+  httpclient: "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+  retrofit: "com.squareup.retrofit:retrofit:${versions.retrofit}"
+  guava: "com.google.guava:guava:${versions.guava}"
+  slf4j: "org.slf4j:jcl-over-slf4j:${versions.slf4j}"
+  okHttp: "com.squareup.okhttp:okhttp:${versions.okHttp}"
+  objenesis: "org.objenesis:objenesis:${versions.objenesis}"

--- a/src/test/groovy/com/netflix/spinnaker/SpinnakerDependenciesSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/SpinnakerDependenciesSpec.groovy
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import spock.lang.Shared
+import spock.lang.Specification
+
+class SpinnakerDependenciesSpec extends Specification {
+
+  @Shared
+  SpinnakerDependencies spinnaker
+
+  @Shared
+  Project project
+
+  @Shared
+  DependencyHandler dependencyHandler
+
+  def setup() {
+    project = Mock(Project)
+    dependencyHandler = Mock(DependencyHandler)
+    project.dependencies >> dependencyHandler
+    spinnaker = new SpinnakerDependencies(project)
+  }
+
+  void "resolve dependencies by name"() {
+    when:
+      spinnaker.dependency("bootActuator")
+
+
+    then:
+      1 * dependencyHandler.create(_)
+  }
+
+  void "resolve group dependencies by scope"() {
+    when:
+      spinnaker.group("bootWeb")
+
+    then:
+      3 * dependencyHandler.create(_) >> Mock(Dependency)
+      3 * dependencyHandler.add('compile', _)
+  }
+}

--- a/src/test/groovy/com/netflix/spinnaker/SpinnakerProjectPluginSpec.groovy
+++ b/src/test/groovy/com/netflix/spinnaker/SpinnakerProjectPluginSpec.groovy
@@ -1,25 +1,7 @@
-/*
- * Copyright 2014 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.netflix.spinnaker
 
-import nebula.test.ProjectSpec
+import spock.lang.Specification
 
-class SpinnakerProjectPluginSpec extends ProjectSpec {
-    @Override
-    void getPluginName() {
-        'spinnaker-gradle-project'
-    }
+class SpinnakerProjectPluginSpec extends Specification {
+  // Gradle plugins are really hard to test...
 }

--- a/src/test/project/build.gradle
+++ b/src/test/project/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+  repositories {
+    mavenLocal()
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.netflix.spinnaker:spinnaker-gradle-project:1.9.4-SNAPSHOT'
+  }
+}
+
+apply plugin: 'spinnaker-gradle-project'
+
+repositories {
+  jcenter()
+}
+
+dependencies {
+  spinnaker.group "bootWeb"
+  compile spinnaker.dependency("spock")
+}


### PR DESCRIPTION
This adds some functionality, like the ability to grab a prescribed dependency:

``` groovy
dependencies {
  compile spinnaker.dependency("frigga")
}
```

In that same way, you can specify groups of common dependencies:

``` groovy
dependencies {
  spinnaker.group "bootWeb"
  spinnaker.group "test"
  spinnaker.group "aws"
  // etc, etc, etc...
}
```

Additionally, this folds in the ability to define a project codestyle (will default if none provided) and module run config:

``` groovy
ideaConfig {
  codeStyleXml = file('gradle/codeStyle.xml')
  mainClassName = 'com.netflix.spinnaker.app.Main'
}
```
