### PR TITLE
Adds spinnaker.package plugin wrapping conventions around building deb/rpm distributions for spinnaker services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     repositories { jcenter() }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.1.2'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
     }
 }
 
@@ -10,6 +10,8 @@ apply plugin: 'groovy'
 apply plugin: 'idea'
 
 group = 'com.netflix.spinnaker.gradle'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 idea {
   project {
@@ -37,6 +39,7 @@ dependencies {
   compile localGroovy()
   compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:latest.release'
   compile 'com.netflix.nebula:gradle-ospackage-plugin:latest.release'
+  compile 'com.netflix.nebula:nebula-ospackage-plugin:latest.release'
   compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:latest.release'
   compile 'org.yaml:snakeyaml:latest.release'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-bin.zip

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -1,0 +1,93 @@
+package com.netflix.spinnaker.gradle.ospackage
+
+import com.netflix.gradle.plugins.packaging.ProjectPackagingExtension
+import nebula.plugin.ospackage.application.OspackageApplicationPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.ApplicationPluginConvention
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.api.tasks.bundling.Jar
+import org.redline_rpm.header.Os
+import org.redline_rpm.payload.Directive
+
+class SpinnakerPackagePlugin implements Plugin<Project> {
+
+    @Override
+    void apply(Project project) {
+        String appName = project.rootProject.name
+        project.plugins.apply(OspackageApplicationPlugin)
+        def appConvention = project.convention.getPlugin(ApplicationPluginConvention)
+        appConvention.applicationName = appName
+        appConvention.applicationDistribution.from(project.file("config/${appName}.yml")) {
+            into('config')
+        }
+        appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom"
+
+        project.tasks.withType(CreateStartScripts) {
+            it.defaultJvmOpts  = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.location=/opt/spinnaker/config/"]
+            it.doLast {
+                unixScript.text = unixScript.text.replace('DEFAULT_JVM_OPTS=', '''\
+                    if [ -f /etc/default/spinnaker ]; then
+                      set -a
+                      . /etc/default/spinnaker
+                      set +a
+                    fi
+                    DEFAULT_JVM_OPTS='''.stripIndent())
+                unixScript.text = unixScript.text.replace('CLASSPATH=$APP_HOME', 'CLASSPATH=$APP_HOME/config:$APP_HOME')
+                windowsScript.text = windowsScript.text.replace('set CLASSPATH=', 'set CLASSPATH=%APP_HOME%\\config;')
+            }
+        }
+
+        project.plugins.withType(JavaBasePlugin)
+        def java = project.convention.getPlugin(JavaPluginConvention)
+        def mainSrc = java.sourceSets.getByName('main')
+        mainSrc.resources.srcDir('src/main/resources')
+        mainSrc.resources.srcDir('config')
+
+        project.tasks.withType(Jar) {
+            it.exclude("${appName}.yml")
+        }
+
+        ProjectPackagingExtension extension = project.extensions.getByType(ProjectPackagingExtension)
+        extension.setOs(Os.LINUX)
+        String projVer = project.version.toString()
+        int idx = projVer.indexOf('-')
+        if (idx != -1) {
+            extension.setVersion(projVer.substring(0, idx))
+        } else {
+            extension.setVersion(projVer)
+        }
+
+        extension.setPackageName('spinnaker-' + appName)
+        def postInstall = project.file('pkg_scripts/postInstall.sh')
+        if (postInstall.exists()) {
+            extension.postInstall(postInstall)
+        }
+        def postUninstall = project.file('pkg_scripts/postUninstall.sh')
+        if (postUninstall.exists()) {
+            extension.postUninstall(postUninstall)
+        }
+
+        def upstartConf = project.file("etc/init/${appName}.conf")
+        if (upstartConf.exists()) {
+            extension.from(upstartConf) {
+                into('/etc/init')
+                setUser('root')
+                setPermissionGroup('root')
+                setFileType(new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_NOREPLACE))
+            }
+        }
+
+        def logrotateConf = project.file("etc/logrotate.d/${appName}")
+        if (logrotateConf.exists()) {
+            extension.from(logrotateConf) {
+                into('/etc/logrotate.d')
+                setUser('root')
+                setPermissionGroup('root')
+                setFileType(new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_NOREPLACE))
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
@@ -17,8 +17,6 @@
 package com.netflix.spinnaker.gradle.project
 
 import com.jfrog.bintray.gradle.BintrayExtension
-import com.jfrog.bintray.gradle.BintrayPlugin
-import com.jfrog.bintray.gradle.BintrayUploadTask
 import com.netflix.spinnaker.gradle.ospackage.OspackageBintrayExtension
 import com.netflix.spinnaker.gradle.ospackage.OspackageBintrayPublishPlugin
 import nebula.plugin.info.scm.ScmInfoExtension

--- a/src/main/resources/META-INF/gradle-plugins/spinnaker.package.properties
+++ b/src/main/resources/META-INF/gradle-plugins/spinnaker.package.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2015 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=com.netflix.spinnaker.gradle.ospackage.SpinnakerPackagePlugin
+


### PR DESCRIPTION
Cleans up a bunch of duplication across projects for builds.

See spinnaker/clouddriver#367 for what the packaging build file will look like after this goes in

cc @skorten @diananana