### PR TITLE
Update logrotate file mode for package plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:latest.release'
+  compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
   compile 'com.netflix.nebula:gradle-ospackage-plugin:latest.release'
   compile 'com.netflix.nebula:nebula-ospackage-plugin:latest.release'
   compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:latest.release'

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
   compile gradleApi()
   compile localGroovy()
   compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
-  compile 'com.netflix.nebula:gradle-ospackage-plugin:latest.release'
-  compile 'com.netflix.nebula:nebula-ospackage-plugin:latest.release'
-  compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:latest.release'
-  compile 'org.yaml:snakeyaml:latest.release'
+  compile 'com.netflix.nebula:gradle-ospackage-plugin:3.4.0'
+  compile 'com.netflix.nebula:nebula-ospackage-plugin:3.1.1'
+  compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'
+  compile 'org.yaml:snakeyaml:1.17'
 }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -86,6 +86,7 @@ class SpinnakerPackagePlugin implements Plugin<Project> {
                 into('/etc/logrotate.d')
                 setUser('root')
                 setPermissionGroup('root')
+                setFileMode(0644)
                 setFileType(new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_NOREPLACE))
             }
         }


### PR DESCRIPTION
Fixes the file permissions for the logrotate file
built with this plugin.

The gradle-netflixoss-project-plugin dependency version is pinned
to 3.2.3 because the latest release causes a build-breaking dependency
conflict when using this plugin with clouddriver.

For Spinnaker issue [#904](https://github.com/spinnaker/spinnaker/issues/904)