### PR TITLE
Adds ability to append build numbers to packages.

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayExtension.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayExtension.groovy
@@ -21,4 +21,5 @@ class OspackageBintrayExtension {
     String debDistribution
     String debComponent
     String debArchitectures
+    String buildNumber
 }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
@@ -46,6 +46,7 @@ class OspackageBintrayPublishPlugin implements Plugin<Project> {
         def packageExtension = project.extensions.create('bintrayPackage', OspackageBintrayExtension)
 
         project.tasks.withType(Deb) { Deb deb ->
+            deb.release = packageExtension.buildNumber
             String debTaskName = "${Character.toUpperCase(deb.name.charAt(0))}${deb.name.substring(1)}"
             def publishDeb = project.tasks.create("publish$debTaskName")
             publishDeb.doFirst {

--- a/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
@@ -68,6 +68,7 @@ class SpinnakerProjectConventionsPlugin implements Plugin<Project> {
             bintrayPackage.debDistribution = 'trusty'
             bintrayPackage.debComponent = 'spinnaker'
             bintrayPackage.debArchitectures = 'i386,amd64'
+            bintrayPackage.buildNumber = propOrDefault('bintrayPackageBuildNumber', '')
         }
 
         project.repositories.jcenter()


### PR DESCRIPTION
We'd like to use build numbers to identify unique debian package builds from source with the same semver. Currently `gradle candidate|final` produces a statically-named debian for all version tags with matching semver when using `-Prelease.useLastTag=true`. For example, it ignores the `$metadata` in `X.Y.Z-$metadata` and produces the same `component_X.Y.Z_all.deb` for any value of `$metadata`. This change adds the ability to create a package of the form `component_X.Y.Z-$build_all.deb` where `-PbintrayPackageBuildNumber=$build`. The previous workflows will be unaffected if this flag is not specified.