### PR TITLE
bump netflixoss plugin version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 buildscript {
-    repositories { jcenter() }
+    repositories {
+      jcenter()
+      maven { url "https://plugins.gradle.org/m2/" }
+    }
     dependencies {
-        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
+        classpath 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.6.0'
     }
 }
 
@@ -31,13 +34,14 @@ bintray {
 
 repositories {
   jcenter()
+  maven { url "https://plugins.gradle.org/m2/" }
 }
 
 
 dependencies {
   compile gradleApi()
   compile localGroovy()
-  compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.2.3'
+  compile 'com.netflix.nebula:gradle-netflixoss-project-plugin:3.6.0'
   compile 'com.netflix.nebula:gradle-ospackage-plugin:3.4.0'
   compile 'com.netflix.nebula:nebula-ospackage-plugin:3.1.1'
   compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.6'


### PR DESCRIPTION
@cfieber ~~I found a copy of the `nl.javadude.gradle.plugins:license-gradle-plugin:0.13.1` transitive dependency in the `http://dl.bintray.com/openmastery/maven` repo, but I'm not sure if it's kosher to link to someone else's bintray account. Can you pull down that dependency and stuff it in `http://spinnaker.bintray.com/gradle`? Is there a preferred method of where to put dependencies?~~

~~Otherwise, we'll need to update each component to include that bintray repo, as I did while trying to test it with Fiat here: https://github.com/ttomsu/fiat/commit/9789dd9b65813c5bbbfb9d9d08e3ca1c3683a294~~ 

I found a copy in the gradle plugin Maven repo. We should still add this to `http://spinnaker.bintray.com/gradle` so that we don't have to add this maven repo to each service.
