### PR TITLE
Redhat systemd location

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -97,7 +97,7 @@ class SpinnakerPackagePlugin implements Plugin<Project> {
         }
 
         def systemdService = project.file("lib/systemd/system/${appName}.service")
-        if (systemdService.exists()) {
+        if (systemdService.exists()) && (systemdPath.exists()) {
             extension.from(systemdService) {
                 into(systemdPath)
                 setUser('root')

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -90,14 +90,14 @@ class SpinnakerPackagePlugin implements Plugin<Project> {
         def yum = 'which yum'.execute()
         apt.waitFor()
         yum.waitFor()
-        if (apt.exitValue() == 0) && (yum.exitValue() == 1) {
+        if (apt.exitValue() == 0 && yum.exitValue() == 1) {
             systemdPath = '/lib/systemd/system'
-        } else if (apt.exitValue() == 1) && (yum.exitValue() == 0) {
+        } else if (apt.exitValue() == 1 && yum.exitValue() == 0) {
             systemdPath = '/usr/lib/systemd/system'
         }
 
         def systemdService = project.file("lib/systemd/system/${appName}.service")
-        if (systemdService.exists()) && (systemdPath.exists()) {
+        if (systemdService.exists() && systemdPath.exists()) {
             extension.from(systemdService) {
                 into(systemdPath)
                 setUser('root')

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -79,11 +79,27 @@ class SpinnakerPackagePlugin implements Plugin<Project> {
                 setFileType(new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_NOREPLACE))
             }
         }
-        
+
+        /* Determine the distro and set the path for systemd unit files
+           if apt exits 0 and yum exits 1 then this is a debian-based
+           OS. Conversely, if apt exits 1 and yum exits 0 it is a
+           redhat-based OS.
+        */
+        String systemdPath
+        def apt = 'which apt'.execute()
+        def yum = 'which yum'.execute()
+        apt.waitFor()
+        yum.waitFor()
+        if (apt.exitValue() == 0) && (yum.exitValue() == 1) {
+            systemdPath = '/lib/systemd/system'
+        } else if (apt.exitValue() == 1) && (yum.exitValue() == 0) {
+            systemdPath = '/usr/lib/systemd/system'
+        }
+
         def systemdService = project.file("lib/systemd/system/${appName}.service")
         if (systemdService.exists()) {
             extension.from(systemdService) {
-                into('/lib/systemd/system')
+                into(systemdPath)
                 setUser('root')
                 setPermissionGroup('root')
                 setFileType(new Directive(Directive.RPMFILE_CONFIG | Directive.RPMFILE_NOREPLACE))


### PR DESCRIPTION
debian and redhat use different paths for their systemd unit files. This patch does two things. 1) determine whether the distro is redhat-based or debian-based and set the systemd path accordingly. 2) Verify this path exists before attempting to write the unit file.