### PR TITLE
fix(package): Don't strip rc version information

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/SpinnakerPackagePlugin.groovy
@@ -54,7 +54,7 @@ class SpinnakerPackagePlugin implements Plugin<Project> {
         extension.setOs(Os.LINUX)
         String projVer = project.version.toString()
         int idx = projVer.indexOf('-')
-        if (idx != -1) {
+        if (idx != -1 && !projVer.contains('-rc.')) {
             extension.setVersion(projVer.substring(0, idx))
         } else {
             extension.setVersion(projVer)


### PR DESCRIPTION
The current package code will take a version like `1.1.1-rc.1` and convert it into `1.1.1`, which will cause conflicts in bintray, as well as falsely release final versions. 

This will produce deb versions like `1.1.1~rc.1`, rather than conflicting versions of repeated `1.1.1`.

@spinnaker/reviewers PTAL