### PR TITLE
fix(ospackage): Skip bintray package upload if release candidate

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
@@ -50,6 +50,13 @@ class OspackageBintrayPublishPlugin implements Plugin<Project> {
             deb.release = packageExtension.buildNumber
             String debTaskName = "${Character.toUpperCase(deb.name.charAt(0))}${deb.name.substring(1)}"
             def publishDeb = project.tasks.create("publish$debTaskName")
+
+            publishDeb.onlyIf {
+                BintrayExtension bintrayCfg = project.extensions.getByType(BintrayExtension)
+                String versionName = bintrayCfg.pkg.version.name ?: project.version.toString()
+                return !versionName.contains('-rc.')
+            }
+
             publishDeb.doFirst {
                 BintrayExtension bintrayCfg = project.extensions.getByType(BintrayExtension)
                 def http = BintrayHttpClientFactory.create(bintrayCfg.apiUrl, bintrayCfg.user, bintrayCfg.key)
@@ -249,6 +256,13 @@ class OspackageBintrayPublishPlugin implements Plugin<Project> {
             rpm.release = packageExtension.buildNumber
             String rpmTaskName = "${Character.toUpperCase(rpm.name.charAt(0))}${rpm.name.substring(1)}"
             def publishRpm = project.tasks.create("publish$rpmTaskName")
+
+            publishRpm.onlyIf {
+                BintrayExtension bintrayCfg = project.extensions.getByType(BintrayExtension)
+                String versionName = bintrayCfg.pkg.version.name ?: project.version.toString()
+                return !versionName.contains('-rc.')
+            }
+
             publishRpm.doFirst {
                 BintrayExtension bintrayCfg = project.extensions.getByType(BintrayExtension)
                 def http = BintrayHttpClientFactory.create(bintrayCfg.apiUrl, bintrayCfg.user, bintrayCfg.key)


### PR DESCRIPTION
It appears that `1.1.1~rc.1` will be resolved first over `1.0.9`, which we don't want during release candidates for people who are actually using bintray debs. This change would have debs publishing be skipped entirely during release candidates.

@spinnaker/reviewers PTAL