### PR TITLE
fix(publish): Make publish call synchronous

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayExtension.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayExtension.groovy
@@ -22,4 +22,5 @@ class OspackageBintrayExtension {
     String debComponent
     String debArchitectures
     String buildNumber
+    int publishWaitForSecs
 }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
@@ -222,7 +222,7 @@ class OspackageBintrayPublishPlugin implements Plugin<Project> {
                     }
                     http.request(POST, JSON) {
                         uri.path = publishUri
-                        body = [publish_wait_for_secs: -1]
+                        body = [publish_wait_for_secs: packageExtension.publishWaitForSecs]
                         response.success = { resp ->
                             project.logger.info("Published '$packagePath/$versionName'.")
                         }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/ospackage/OspackageBintrayPublishPlugin.groovy
@@ -222,6 +222,7 @@ class OspackageBintrayPublishPlugin implements Plugin<Project> {
                     }
                     http.request(POST, JSON) {
                         uri.path = publishUri
+                        body = [publish_wait_for_secs: -1]
                         response.success = { resp ->
                             project.logger.info("Published '$packagePath/$versionName'.")
                         }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectConventionsPlugin.groovy
@@ -69,6 +69,7 @@ class SpinnakerProjectConventionsPlugin implements Plugin<Project> {
             bintrayPackage.debComponent = 'spinnaker'
             bintrayPackage.debArchitectures = 'i386,amd64'
             bintrayPackage.buildNumber = propOrDefault('bintrayPackageBuildNumber', '')
+            bintrayPackage.publishWaitForSecs = propOrDefault('bintrayPublishWaitForSecs', '0').toInteger()
         }
 
         project.repositories.jcenter()


### PR DESCRIPTION
The Bintray API provides both a synchronous and an asynchronous version of their publish API. We're currently using the asynchronous version, and returning success immediately; this is sometimes causing downstream steps in our build and validate pipleline to fail because they start before the package has actually be published. Change the publish call to be synchronous, so that Gradle task only completes when the publish has completed, and later steps can rely on the existence of the package.