### PR TITLE
feat(plugin): Add a plugin for third party license report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,4 +45,5 @@ dependencies {
   compile 'com.netflix.nebula:gradle-ospackage-plugin:4.9.3'
   compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.1'
   compile 'org.yaml:snakeyaml:1.17'
+  compile 'gradle.plugin.com.github.jk1:gradle-license-report:1.2'
 }

--- a/src/main/groovy/com/netflix/spinnaker/gradle/license/SpinnakerLicenseReportPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/license/SpinnakerLicenseReportPlugin.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.license
+
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.LicenseReportPlugin
+import com.github.jk1.license.filter.LicenseBundleNormalizer
+import com.github.jk1.license.render.CsvReportRenderer
+import com.github.jk1.license.render.InventoryHtmlReportRenderer
+import com.github.jk1.license.render.JsonReportRenderer
+import groovy.json.JsonSlurper
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.plugins.ProjectReportsPlugin
+
+import static com.github.jk1.license.filter.LicenseBundleNormalizer.*
+
+class SpinnakerLicenseReportPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.plugins.apply(ProjectReportsPlugin)
+        project.plugins.apply(LicenseReportPlugin)
+
+        LicenseReportExtension pluginConfig = project.extensions.getByType(LicenseReportExtension)
+        pluginConfig.configurations = [ 'ALL' ]
+        pluginConfig.renderers = [
+                new InventoryHtmlReportRenderer(),
+                new CsvReportRenderer(),
+                new JsonReportRenderer() ]
+
+        def licenseBundleNormalizer = new LicenseBundleNormalizer()
+        addSpinnakerNormalizerBundle(licenseBundleNormalizer.normalizerConfig)
+        pluginConfig.filters = [ licenseBundleNormalizer ]
+    }
+
+    def addSpinnakerNormalizerBundle(LicenseBundleNormalizerConfig config) {
+        def additionalConfig = new JsonSlurper().parse(getClass().getResourceAsStream("/license-normalizer-bundle.json"))
+
+        additionalConfig.bundles.each {
+            config.bundles.add(new NormalizerLicenseBundle(it))
+        }
+
+        additionalConfig.transformationRules.each {
+            config.transformationRules.add(new NormalizerTransformationRule(it))
+        }
+    }
+}

--- a/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.gradle.project
 
 import com.netflix.spinnaker.gradle.dependency.SpinnakerDependencyPlugin
 import com.netflix.spinnaker.gradle.idea.SpinnakerIdeaConfigPlugin
+import com.netflix.spinnaker.gradle.license.SpinnakerLicenseReportPlugin
 import com.netflix.spinnaker.gradle.ospackage.OspackageBintrayPublishPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -30,5 +31,6 @@ class SpinnakerProjectPlugin implements Plugin<Project> {
         project.plugins.apply(SpinnakerDependencyPlugin)
         project.plugins.apply(OspackageBintrayPublishPlugin)
         project.plugins.apply(SpinnakerProjectConventionsPlugin)
+        project.plugins.apply(SpinnakerLicenseReportPlugin)
     }
 }

--- a/src/main/resources/META-INF/gradle-plugins/spinnaker.license-report.properties
+++ b/src/main/resources/META-INF/gradle-plugins/spinnaker.license-report.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.spinnaker.gradle.dependency.SpinnakerLicenseReportPlugin

--- a/src/main/resources/license-normalizer-bundle.json
+++ b/src/main/resources/license-normalizer-bundle.json
@@ -1,0 +1,29 @@
+{
+  "bundles" : [
+    { "bundleName" : "apache1", "licenseName" : "Apache Software License, Version 1.1", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-1.1" },
+    { "bundleName" : "apache2", "licenseName" : "Apache License, Version 2.0", "licenseUrl" : "http://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "cddl1", "licenseName" : "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE Version 1.0 (CDDL-1.0)", "licenseUrl" : "http://opensource.org/licenses/CDDL-1.0" },
+    { "bundleName" : "cddl+gpl", "licenseName" : "CDDL+GPL License", "licenseUrl" : "http://glassfish.java.net/public/CDDL+GPL_1_1.html" },
+    { "bundleName" : "mit", "licenseName" : "The MIT License (MIT)", "licenseUrl" : "http://opensource.org/licenses/MIT" },
+    { "bundleName" : "epl", "licenseName" : "Eclipse Public License - Version 1.0", "licenseUrl" : "http://www.eclipse.org/org/documents/epl-v10.php" },
+    { "bundleName" : "lgpl2.1", "licenseName" : "LGPL 2.1", "licenseUrl" : "http://www.gnu.org/licenses/lgpl-2.1.html" },
+    { "bundleName" : "bsd", "licenseName" : "BSD", "licenseUrl" : "http://www.opensource.org/licenses/bsd-license.php" }
+  ],
+  "transformationRules" : [
+    { "bundleName" : "apache2", "licenseNamePattern" : ".*The Apache Software License, Version 2.0.*" },
+    { "bundleName" : "apache2", "licenseNamePattern" : "Apache 2" },
+    { "bundleName" : "apache2", "licenseNamePattern" : "Apache License 2.0" },
+    { "bundleName" : "apache2", "licenseUrlPattern" : "http://www.apache.org/licenses/LICENSE-2.0" },
+    { "bundleName" : "apache2", "licenseNamePattern" : "Special Apache", "transformUrl" : false },
+    { "bundleName" : "apache2", "licenseNamePattern" : "Keep this name", "transformName" : false },
+    { "bundleName" : "mit", "licenseNamePattern" : ".*MIT.*", "transformUrl" : false },
+    { "bundleName" : "cddl+gpl", "licenseUrlPattern" : ".*CDDL+GPL.*", "transformUrl" : false },
+    { "bundleName" : "cddl+gpl", "licenseNamePattern" : "CDDL 1.1", "transformUrl" : false },
+    { "bundleName" : "cddl+gpl", "licenseNamePattern" : "GPLv2+CE", "transformUrl" : false },
+    { "bundleName" : "epl", "licenseUrlPattern" : "http://www.eclipse.org/org/documents/epl-v10.*"},
+    { "bundleName" : "epl", "licenseNamePattern" : ".*Eclipse Public License.*"},
+    { "bundleName" : "lgpl2.1", "licenseNamePattern" : "LGPL.*2.1", "transformUrl" : false},
+    { "bundleName" : "bsd", "licenseUrlPattern" : "http://www.opensource.org/licenses/bsd-license.*", "transformUrl" : false},
+    { "bundleName" : "bsd", "licenseNamePattern" : ".*BSD.*", "transformUrl" : false}
+  ]
+}


### PR DESCRIPTION
License reports can be run by the `generateLicenseReport` task.

Addresses https://github.com/spinnaker/spinnaker/issues/3294