### PR TITLE
feat(plugins): Include vulnerability scan plugin to base-project.

### DIFF
--- a/spinnaker-dev-plugin/build.gradle
+++ b/spinnaker-dev-plugin/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
   compile 'org.yaml:snakeyaml:1.21'
   compile 'gradle.plugin.com.github.jk1:gradle-license-report:1.2'
+  compile 'org.owasp:dependency-check-gradle:3.3.2'
 }
 

--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectPlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectPlugin.groovy
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.gradle.baseproject
 import com.netflix.spinnaker.gradle.dependency.SpinnakerDependencyPlugin
 import com.netflix.spinnaker.gradle.idea.SpinnakerIdeaConfigPlugin
 import com.netflix.spinnaker.gradle.license.SpinnakerLicenseReportPlugin
+import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -12,5 +13,6 @@ class SpinnakerBaseProjectPlugin implements Plugin<Project> {
         project.plugins.apply(SpinnakerBaseProjectConventionsPlugin)
         project.plugins.apply(SpinnakerIdeaConfigPlugin)
         project.plugins.apply(SpinnakerDependencyPlugin)
+        project.plugins.apply(DependencyCheckPlugin)
     }
 }


### PR DESCRIPTION
This PR  adds the plugin to the `spinnaker.base-project`. Scans can be run on demand by running `./gradlew dependencyCheckAggregate`


https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/index.html