### PR TITLE
fix(builds): Undo switch of rootproject from allprojects

### DIFF
--- a/spinnaker-gradle-project/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
+++ b/spinnaker-gradle-project/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
@@ -28,7 +28,7 @@ class SpinnakerProjectPlugin implements Plugin<Gradle> {
 
     @Override
     void apply(Gradle gradle) {
-        gradle.rootProject { project ->
+        gradle.allprojects { project ->
             project.plugins.apply(NetflixOssProjectPlugin)
             project.plugins.apply(SpinnakerBintrayPublishingPlugin)
 


### PR DESCRIPTION
Undoing the `allprojects` change and releasing