### PR TITLE
fix(formatter): remove .md files from auto formatting

### DIFF
--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
@@ -71,7 +71,7 @@ class SpinnakerCodeStylePlugin implements Plugin<Project> {
           new Action<FormatExtension>() {
             @Override
             void execute(FormatExtension formatExtension) {
-              formatExtension.target('**/*.md', '**/.gitignore', '**/*.json', '**/*.yml', '**/*.yaml', '**/*.gradle')
+              formatExtension.target('**/.gitignore', '**/*.json', '**/*.yml', '**/*.yaml', '**/*.gradle')
               formatExtension.trimTrailingWhitespace()
               formatExtension.indentWithSpaces(2)
               formatExtension.endWithNewline()


### PR DESCRIPTION
the autoformatting does whacky things to markdown, no point having it on for them