### PR TITLE
fix(*): Make config defaulting comptatible with boot2

### DIFF
--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
@@ -22,13 +22,7 @@ class SpinnakerApplicationPlugin implements Plugin<Project> {
         appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom"
 
         project.tasks.withType(CreateStartScripts) {
-            // In Spring Boot 2, spring.config.location overrides the default locations and
-            // spring.config.additional-location should be used to augment the defaults instead of overriding.
-            // To keep this compatible with Spring Boot 1 and 2, still use 'spring.config.location'
-            // but explicitly add in the default config paths (which are unchanged between Boot 1 and 2).
-            // Once all services are on boot 2, this can be changed to additional-location
-            // and the defaults can be removed.
-            it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.location=classpath:/,classpath:/config/,file:./,file:./config/,/opt/spinnaker/config/"]
+            it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.additional-location=/opt/spinnaker/config/"]
             it.doLast {
                 unixScript.text = unixScript.text.replace('DEFAULT_JVM_OPTS=', '''\
                     if [ -f /etc/default/spinnaker ]; then

--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
@@ -22,7 +22,13 @@ class SpinnakerApplicationPlugin implements Plugin<Project> {
         appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom"
 
         project.tasks.withType(CreateStartScripts) {
-            it.defaultJvmOpts  = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.location=/opt/spinnaker/config/"]
+            // In Spring Boot 2, spring.config.location overrides the default locations and
+            // spring.config.additional-location should be used to augment the defaults instead of overriding.
+            // To keep this compatible with Spring Boot 1 and 2, still use 'spring.config.location'
+            // but explicitly add in the default config paths (which are unchanged between Boot 1 and 2).
+            // Once all services are on boot 2, this can be changed to additional-location
+            // and the defaults can be removed.
+            it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.location=classpath:/,classpath:/config/,file:./,file:./config/,/opt/spinnaker/config/"]
             it.doLast {
                 unixScript.text = unixScript.text.replace('DEFAULT_JVM_OPTS=', '''\
                     if [ -f /etc/default/spinnaker ]; then


### PR DESCRIPTION
In boot2, spring.config.location overrides the default instead of adding to it; this means that we're no longer pulling in the default config file for the service.

We could change to using additional-location but this isn't supported for services still on boot1. Instead, just manually add in the default locations (which are the same for boot 1 and 2) before /opt/spinnaker/config. Once we are fully on boot2, we can remove the defaults and change the parameter to additional-locations.