### PR TITLE
fix(codestyles): Simplify & fix pre-commit hook

### DIFF
--- a/spinnaker-dev-plugin/src/main/resources/pre-commit
+++ b/spinnaker-dev-plugin/src/main/resources/pre-commit
@@ -1,21 +1,7 @@
 #!/bin/sh
 echo '[git hook] executing gradle spotlessCheck before commit'
 
-# stash any unstaged changess
-git diff --quiet HEAD
-HASUNSTAGED=$?
-
-if [ "$HASUNSTAGED" -eq "1" ]; then
-  git stash -q --keep-index
-fi
-
 ./gradlew spotlessApply
-
-git add .
-
-# unstash the unstaged changes, if any
-if [ "$HASUNSTAGED" -eq "1" ]; then
-  git stash pop -q
-fi
+git diff --name-only --staged | xargs git add
 
 exit 0


### PR DESCRIPTION
This will re-stage any changed files from applying codestyles that were staged at the time of commit. It won't cover all cases (like the code formatter finding new things that you didn't change), but it's immensely easy to reason about.