### PR TITLE
fix(style): scope spotlessMisc to source files

### DIFF
--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
@@ -71,7 +71,7 @@ class SpinnakerCodeStylePlugin implements Plugin<Project> {
           new Action<FormatExtension>() {
             @Override
             void execute(FormatExtension formatExtension) {
-              formatExtension.target('**/.gitignore', '**/*.json', '**/*.yml', '**/*.yaml', '**/*.gradle')
+              formatExtension.target('**/.gitignore', 'src/**/*.json', 'src/**/*.yml', 'src/**/*.yaml', 'config/*.yml', 'halconfig/*.yml', '**/*.gradle')
               formatExtension.trimTrailingWhitespace()
               formatExtension.indentWithSpaces(2)
               formatExtension.endWithNewline()


### PR DESCRIPTION
Eliminates spurrious failures against generated content such as swagger.json