### PR TITLE
chore(dependencies): update spotless plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-spotlessVersion=3.23.1
+spotlessVersion=3.25.0
 gradleNetflixOssProjectVersion=8.0.0
 


### PR DESCRIPTION
newer version is required for projects using Gradle 6.0