### PR TITLE
fix(extensions): Fix case-insentivive sourceset resolution

### DIFF
--- a/gradle/kotlin-test.gradle
+++ b/gradle/kotlin-test.gradle
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This gradle file should be used only when you want to write tests in Kotlin, but
+// do not want to ship Kotlin as a dependency to library consumers.
+
+apply plugin: "kotlin"
+
+dependencies {
+  testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.41"
+
+  testImplementation "org.junit.jupiter:junit-jupiter-api"
+  testImplementation "org.junit.platform:junit-platform-runner"
+  testImplementation "org.assertj:assertj-core"
+  testImplementation "io.strikt:strikt-core"
+  testImplementation "dev.minutest:minutest"
+  testImplementation "io.mockk:mockk"
+
+  testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
+}
+
+test {
+  useJUnitPlatform {
+    includeEngines "junit-jupiter"
+  }
+}
+
+compileTestKotlin {
+  kotlinOptions {
+    languageVersion = "1.3"
+    jvmTarget = "1.8"
+  }
+}

--- a/spinnaker-extensions/build.gradle.kts
+++ b/spinnaker-extensions/build.gradle.kts
@@ -53,11 +53,11 @@ gradlePlugin {
 }
 
 // Add a source set for the functional test suite
-val functionalTestSourceSet = sourceSets.create("functionalTest") {
+val functionalTestSourceSet = sourceSets.create("functionaltest") {
 }
 
 gradlePlugin.testSourceSets(functionalTestSourceSet)
-configurations.getByName("functionalTestImplementation").extendsFrom(configurations.getByName("testImplementation"))
+configurations.getByName("functionaltestImplementation").extendsFrom(configurations.getByName("testImplementation"))
 
 // Add a task to run the functional tests
 val functionalTest by tasks.creating(Test::class) {

--- a/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginFunctionalTest.kt
+++ b/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginFunctionalTest.kt
@@ -27,29 +27,27 @@ import kotlin.test.assertTrue
  */
 class SpinnakerExtensionGradlePluginFunctionalTest {
 
-  @Ignore
-    @Test fun `can run task`() {
-        // Setup the test build
-        val projectDir = File("build/functionaltest")
-        projectDir.mkdirs()
-        projectDir.resolve("settings.gradle").writeText("")
-        projectDir.resolve("build.gradle").writeText("""
-            plugins {
-                id('java')
-                id('io.spinnaker.plugin.service-extension')
-            }
-        """)
+  @Test fun `can run task`() {
+    // Setup the test build
+    val projectDir = File("build/functionaltest")
+    projectDir.mkdirs()
+    projectDir.resolve("settings.gradle").writeText("")
+    projectDir.resolve("build.gradle").writeText("""
+        plugins {
+            id('io.spinnaker.plugin.bundler')
+        }
+    """)
 
-        // Run the build
-        val runner = GradleRunner.create()
-        runner.forwardOutput()
-        runner.withPluginClasspath()
-        runner.withArguments("assemblePluginZip")
-        runner.withProjectDir(projectDir)
-        val result = runner.build()
+    // Run the build
+    val runner = GradleRunner.create()
+    runner.forwardOutput()
+    runner.withPluginClasspath()
+    runner.withArguments("collectPluginZips")
+    runner.withProjectDir(projectDir)
+    val result = runner.build()
 
-        // Verify the result
-        assertTrue(result.output.contains("BUILD SUCCESSFUL"))
-    }
+    // Verify the result
+    assertTrue(result.output.contains("BUILD SUCCESSFUL"))
+  }
 
 }


### PR DESCRIPTION
Mixed casing issue with `functionalTest` on OSX that would cause functional tests to
throw exceptions on run.

Also includes gradle config for the standard kotlin test suite, which I plan to switch things to as I build out more tests for the stuff I jammed in last week.