### PR TITLE
feat(plugins): Removing more boilerplate from plugin projects

### DIFF
--- a/spinnaker-extensions/README.md
+++ b/spinnaker-extensions/README.md
@@ -1,10 +1,23 @@
-## Gradle plugin for supporting spinnaker plugin implementations.
+# Gradle plugin for supporting spinnaker plugin implementations.
 
 This **gradle** plugin allows Spinnaker developers to bundle, publish and register **_"spinnaker plugins"_** with spinnaker.
 
-### Usage
+Plugins are bundled into two artifacts: A "plugin bundle" and a "plugin info" manifest. These can be found in the project's
+root build directory: `build/distributions`. The plugin bundle will be a `{your-plugin}-{version}.zip` file, whereas the
+plugin info manifest will always be `plugin-info.json`.
+
+An example repository can be found at [robzienert/spinnaker-plugin-helloworld](https://github.com/robzienert/spinnaker-plugin-helloworld).
+
+## Usage
+
+Spinnaker plugin development is broken up into 3 different Gradle plugins within `spinnaker-extensions`:
+
+* `bundler`, applied to the root project only, configures metadata and packages plugins into a bundle consumable by Spinnaker.
+* `ui-extension`, applied only to the subproject containing Deck code, configures the module for building Deck plugins.
+* `service-extension`, applied only to backend service subprojects, configures the module for building backend service plugins.
 
 ```groovy
+// build.gradle
 buildscript {
   repositories {
     maven { url "https://dl.bintray.com/spinnaker/gradle/" }
@@ -13,38 +26,48 @@ buildscript {
     classpath("com.netflix.spinnaker.gradle:spinnaker-extensions:$spinnakerGradleVersion")
   }
 }
+
+// settings.gradle
+spinnakerGradleVersion=LATEST_VERSION_HERE
 ```
 
 * Root project must `apply plugin: "io.spinnaker.plugin.bundler`
 * Deck extension module must `apply plugin: "io.spinnaker.plugin.ui-extension`
 * Backend extension modules must `apply plugin: "io.spinnaker.plugin.service-extension`
 
-#### Root Module
+Once configured: `./gradlew releaseBundle`
+
+### Root Module
+
+The root module must not be responsible for building any plugin code.
+It's purpose is to configure plugin metadata and bundle service plugins from subprojects within the repository into a single artifact.
 
 ```groovy
 apply plugin: "io.spinnaker.plugin.bundler"
 
 spinnakerBundle {
   pluginId    = "com.netflix.streaming.platform.cde.aws-rds"
-  description = "AWS RDS infrastructure management"
-  version     = "1.0.0" // Will be inferred from git tags if undefined
+  description = "Provides AWS RDS infrastructure management"
+  version     = "1.0.0"
   provider    = "https://github.com/Netflix"
 }
 ```
 
-#### Service Modules
+* `pluginId`: The plugin ID for the bundled plugins.
+This should be considered the root namespace of all plugins contained within your repository.
+Must follow the [`CanonicalPluginId`](https://github.com/spinnaker/kork/blob/master/kork-plugins/src/main/kotlin/com/netflix/spinnaker/kork/plugins/CanonicalPluginId.kt) format.
+* `description`: A description of what the plugin does.
+* `version`: The version of the plugin. This value will be inferred from the repository git tags on build if left undefined.
+* `provider`: The plugin provider (that's you). Using your Github profile (or something equivalent) can be used.
+
+### Service Modules
+
+Modules for extending backend services like Orca, Clouddriver, Fiat.
 
 ```groovy
-apply plugin: "java"
 apply plugin: "io.spinnaker.plugin.service-extension"
 
-repositories {
-  jcenter()
-  maven { url "http://dl.bintray.com/spinnaker/spinnaker/" }
-}
-
 dependencies {
-  annotationProcessor "org.pf4j:pf4j:3.2.0"
   compileOnly("com.netflix.spinnaker.kork:kork-plugins-api:$korkVersion")
 }
 
@@ -55,7 +78,10 @@ spinnakerPlugin {
 }
 ```
 
-#### Deck Module
+### Deck Module
+
+Module for extending Deck.
+The `deck-plugins` package provides many of the conventions needed for plugin development within Deck: This just wires its conventions up to the bundler.
 
 ```groovy
 apply plugin: "io.spinnaker.plugin.ui-extension"
@@ -66,9 +92,5 @@ apply plugin: "io.spinnaker.plugin.ui-extension"
 * Expects multi-project gradle builds where each sub project implements extensions targeting a single spinnaker service.
 * Storage for plugin artifacts(bundled zip) can be like S3, GCS, jCenter or artifactory etc. ????
 
-
-- [x] Compute Checksum for each artifact
-- [x] Bundle up plugin artifacts into a single ZIP
-- [ ] Deck artifacts zip with in the module and collect the same in the plugin bundle ?
 - [ ] Publish bundle to ??
 - [ ] How to register it with spinnaker ??

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.gradle.extension
 import org.gradle.api.Project
 
 object Plugins {
+  const val PF4J_VERSION = "3.2.0"
+
   const val GROUP = "Spinnaker Plugins"
 
   const val BUNDLE_PLUGINS_TASK_NAME = "bundlePlugins"

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
@@ -41,14 +41,12 @@ class SpinnakerUIExtensionPlugin : Plugin<Project> {
     project.tasks.create(ASSEMBLE_PLUGIN_TASK_NAME, AssembleUIPluginTask::class.java)
     project.tasks.create("buildUi", BuildUIExtensionTask::class.java)
 
-    project.afterEvaluate {
-      project.tasks.getByName("build").dependsOn("buildUi")
-      project.tasks
-        .getByName("clean")
-        .dependsOn("yarn_cache_clean")
-        .doLast {
-          project.delete(project.files("${project.projectDir}/node_modules"))
-        }
-    }
+    project.tasks.getByName("build").dependsOn("buildUi")
+    project.tasks
+      .getByName("clean")
+      .dependsOn("yarn_cache_clean")
+      .doLast {
+        project.delete(project.files("${project.projectDir}/node_modules"))
+      }
   }
 }


### PR DESCRIPTION
- PF4J annotation processor dependency is always applied to `service-extension` modules
- Spinnaker bintray maven repo is always applied to `service-extension` modules
- Updated README to have a little more information about setup and config.