### PR TITLE
fix(plugins): plugin ref file name should mention project

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -69,7 +69,7 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     manifest.attributes(attributes)
 
     //TODO: Generation of the plugin ref can be conditional and also make the location of the file configurable.
-    createPluginRef(project, pluginExt.serviceName, this.temporaryDir.absolutePath)
+    createPluginRef(project, "${bundleExt.pluginId}-${pluginExt.serviceName}", this.temporaryDir.absolutePath)
 
   }
 


### PR DESCRIPTION
If it is just the service name (orca.plugin-ref) then you have to rename before using multiple plugin refs in orca/plugins or they have name collisions.