### PR TITLE
feat(version): Add optional property ossVersion to specify Implementation-OSS-Version attribute

### DIFF
--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.jvm.tasks.Jar
 
 class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
     @Override
@@ -15,12 +16,29 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
         convention.sourceCompatibility = JavaVersion.VERSION_1_8
         convention.targetCompatibility = JavaVersion.VERSION_1_8
       }
+      project.tasks.withType(Jar) { setImplementationOssVersion((it as Jar), project) }
       project.afterEvaluate {
         project.tasks
           .getByName("clean")
           .doLast {
             project.delete(project.files("${project.projectDir}/plugins"))
           }
+      }
+    }
+
+  /**
+   * If this the property "ossVersion" exists the MANIFEST.MF "Implementation-OSS-Version" attribute
+   * will be set to the corresponding property. This can be used to support use cases where services
+   * are being extended and rebuilt.  Unless you're re-building services, this is likely unnecessary
+   * and the default value of the attribute "Implementation-Version" will suffice for determining
+   * the service version.
+   */
+    private static void setImplementationOssVersion(Jar jar, Project project) {
+      String ossVersionProperty = "ossVersion"
+      if (project.hasProperty(ossVersionProperty)) {
+        jar.manifest {
+          it.attributes(["Implementation-OSS-Version": project.property(ossVersionProperty)])
+        }
       }
     }
 }


### PR DESCRIPTION
Downstream builds should be able to pass in `-PossVersion=1.0.1` for example and set this attribute.