### PR TITLE
feat(java11): allow conditionally turning on the cross-compiler plugin

### DIFF
--- a/spinnaker-dev-plugin/build.gradle
+++ b/spinnaker-dev-plugin/build.gradle
@@ -3,6 +3,7 @@ dependencies {
   compile 'org.owasp:dependency-check-gradle:5.1.0'
   compile "com.diffplug.spotless:spotless-plugin-gradle:$spotlessVersion"
   compile 'org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r'
+  compile 'com.netflix.nebula:gradle-java-cross-compile-plugin:4.1.0'
 }
 gradlePlugin {
     plugins {

--- a/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectPlugin.groovy
+++ b/spinnaker-dev-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectPlugin.groovy
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.gradle.codestyle.SpinnakerCodeStylePlugin
 import com.netflix.spinnaker.gradle.idea.SpinnakerIdeaConfigPlugin
 import com.netflix.spinnaker.gradle.idea.SpinnakerNewIdeaProjectPlugin
 import com.netflix.spinnaker.gradle.license.SpinnakerLicenseReportPlugin
+import nebula.plugin.compile.JavaCrossCompilePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.owasp.dependencycheck.gradle.DependencyCheckPlugin
@@ -17,5 +18,8 @@ class SpinnakerBaseProjectPlugin implements Plugin<Project> {
         project.plugins.apply(SpinnakerLicenseReportPlugin)
         project.plugins.apply(DependencyCheckPlugin)
         project.plugins.apply(SpinnakerCodeStylePlugin)
+        if (Boolean.valueOf(project.findProperty("enableCrossCompilerPlugin")?.toString())) {
+            project.plugins.apply(JavaCrossCompilePlugin)
+        }
     }
 }


### PR DESCRIPTION
The [cross-compiler plugin](https://github.com/nebula-plugins/gradle-java-cross-compile-plugin) requires a little additional setup (you have to set
the JDK_18 environment variable to point at a Java 1.8 JDK) but it fixes an
issue with Groovy and Kotlin compilation, where it prevents you from calling
Java 11 APIs when cross-compiling to Java 8. (For javac, you just have to say
`--release 8`, but setting it up for Groovy and Kotlin is more complicated.)

The Netflix Nebula plugin turns this on automatically, but only for "candidate"
builds, which is why my Java 11 merges succeeded with container builds and PR
GHA builds, but failed with the Debian builds and post-merge GHA builds. (It
failed because we didn't have "JDK_18" set.) So at first I was annoyed about
that because it's going to be a bit of a pain to configure (you'll see soon
enough), but then when I looked into it more I realized it's a pretty helpful
plugin, so I decided to embrace it.

I don't think we want to enable this all the time, or else developers will also
have to set that variable (which is why it's only enabled for the "candidate"
target). But I would like to turn it on for container and PR builds.