### PR TITLE
chore(bumpdeps): enable the bumpdeps workflow

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -1,0 +1,17 @@
+name: Bump Dependencies
+
+on:
+  repository_dispatch:
+    types: [bump-dependencies]
+
+jobs:
+  bump-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: spinnaker/bumpdeps@master
+      with:
+        ref: ${{ github.event.client_payload.ref }}
+        key: spinnakerGradleVersion
+        repositories: echo,fiat,keiko
+      env:
+        GITHUB_OAUTH: ${{ secrets.REPO_OAUTH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,11 @@ jobs:
             ${{ steps.release_info.outputs.CHANGELOG }}
            draft: false
            prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
+      - name : Pause before dependency bump
+        run: sleep 90
+      - name: Trigger dependency bump workflow
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}
+          event-type: bump-dependencies
+          client-payload: '{"ref": "${{ github.ref }}"}'


### PR DESCRIPTION
Just for three repositories right now. I just want to start small before
turning it on everywhere. (And all three of these repositories already
have very recent versions of spinnakerGradleVersions.)