### PR TITLE
chore(release): fix the secret name

### DIFF
--- a/.github/workflows/bump_dependencies.yml
+++ b/.github/workflows/bump_dependencies.yml
@@ -14,4 +14,4 @@ jobs:
         key: spinnakerGradleVersion
         repositories: echo,fiat,keiko
       env:
-        GITHUB_OAUTH: ${{ secrets.REPO_OAUTH_TOKEN }}
+        GITHUB_OAUTH: ${{ secrets.SPINNAKER_GITHUB_TOKEN }}


### PR DESCRIPTION
I forgot to update this from the one I was using for testing.

Do you know of any reasonable way to trigger this workflow again for v7.11.0, or do I just have to create a pointless v7.12.0?