### PR TITLE
fix(plugins): Correctly source dependencies from lib directory

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -83,7 +83,7 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     val pluginRelInfo = mapOf(
       "pluginPath" to manifestLocation,
       "classesDirs" to classesDirs,
-      "libsDirs" to listOf("${project.buildDir}/libs")
+      "libsDirs" to listOf("${project.buildDir}/lib")
     )
 
     File(project.buildDir, "${pluginExtensionName ?: project.name}.plugin-ref").writeText(

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
@@ -44,7 +44,7 @@ open class AssembleJavaPluginZipTask : Zip() {
     this.with(
       // TODO(rz): Make sure kork / service deps are not included (compileOnly)
       project.copySpec().from(sourceSets.getByName("main").compileClasspath)
-        .into("libs/"),
+        .into("lib/"),
       project.copySpec()
         .from(sourceSets.getByName("main").runtimeClasspath)
         .from(sourceSets.getByName("main").resources)


### PR DESCRIPTION
PF4J looks to the `lib` directory, not `libs`.