### PR TITLE
fix(plugins): allow plugin dependencies

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -80,10 +80,13 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     val classesDirs: List<String>  = sourceSets.getByName("main").runtimeClasspath.files.map { it ->
       it.absolutePath
     }
+    val libDirs: List<String>  = sourceSets.getByName("main").runtimeClasspath.files
+      .filter { it.absolutePath.endsWith(".jar") }
+      .map { it.parent }
     val pluginRelInfo = mapOf(
       "pluginPath" to manifestLocation,
       "classesDirs" to classesDirs,
-      "libsDirs" to listOf("${project.buildDir}/lib")
+      "libsDirs" to listOf("${project.buildDir}/lib", *(libDirs.toTypedArray()))
     )
 
     File(project.buildDir, "${pluginExtensionName ?: project.name}.plugin-ref").writeText(

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
@@ -41,10 +41,14 @@ open class AssembleJavaPluginZipTask : Zip() {
 
     val sourceSets = project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets
 
+    val configs = listOf("implementation", "runtimeOnly").map { project.configurations.getByName(it).copy() }
+    configs.forEach { it.isCanBeResolved  = true }
+    val copySpecs = configs.map {
+      project.copySpec().from(it)
+        .into("lib/")
+    }
     this.with(
-      // TODO(rz): Make sure kork / service deps are not included (compileOnly)
-      project.copySpec().from(sourceSets.getByName("main").compileClasspath)
-        .into("lib/"),
+      *(copySpecs.toTypedArray()),
       project.copySpec()
         .from(sourceSets.getByName("main").runtimeClasspath)
         .from(sourceSets.getByName("main").resources)


### PR DESCRIPTION
Now that the dependencies are correctly put in 'lib' and actually used, we can no longer load plugins. This is because the provided (compileOnly) dependencies like kork and spin services are packaged into the plugin and there are classpath issues (duplicate ExtensionConfiguration for example). This change bundles only implementation (compile is included) and runtimeOnly dependencies. Strangely, the "canBeResolved" flag needs to be set on these configs, and a copy of them has to be made first or you get errors about modifying the configs when running unit tests.
I also added the dirs containing the jars to the 'libsDirs' section of the .plugin-ref so that the dependencies are used in debugging mode too.