### PR TITLE
fix(bintrayPublish): change bintray jar lifecycle to fix HTTP errors

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayCreateVersionTask.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayCreateVersionTask.groovy
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.gradle.publishing.bintray
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+class BintrayCreateVersionTask extends DefaultTask {
+  @Input
+  Provider<String> createVersionUri
+
+  @Input
+  Provider<String> packageName
+
+  @Input
+  String bintrayAuthHeader
+
+  @TaskAction
+  void createVersion() {
+    def url = createVersionUri.get()
+    def http = new HttpUtil(url, bintrayAuthHeader, 'POST')
+    String createVersion = """\
+    {
+      "name": "${project.version}",
+      "desc": "${packageName.get()} ${project.version}"
+    }
+    """.stripIndent()
+    project.logger.info("POSTing create version request to $url")
+    http.uploadJson(createVersion)
+    project.logger.info("Waiting for HTTP response")
+    def response = http.response
+    project.logger.info("Create Version request finished with status $response.responseCode: $response.statusLine")
+    project.logger.debug("Create Version response:\n$response.responseBody")
+  }
+}

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayDebUploadTask.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayDebUploadTask.groovy
@@ -12,41 +12,22 @@ class BintrayDebUploadTask extends DefaultTask {
   @Input
   Provider<String> publishUri
 
+  @Input
+  String bintrayAuthHeader
+
   @InputFile
   Provider<RegularFile> archiveFile
 
   @TaskAction
   void uploadDeb() {
-    def extension = project.extensions.getByType(BintrayPublishExtension)
-    def url = publishUri.get().toURL()
+    def url = publishUri.get()
+    def http = new HttpUtil(url, bintrayAuthHeader, 'PUT')
     def file = archiveFile.get().asFile
-    def contentLength = file.size()
     project.logger.info("Uploading $file to $url")
-    HttpURLConnection con = (HttpURLConnection) url.openConnection()
-    con.doOutput = true
-    con.requestMethod = 'PUT'
-    con.addRequestProperty('Authorization', extension.basicAuthHeader())
-    con.setRequestProperty('Content-Type', 'application/octet-stream')
-    con.setRequestProperty('Content-Length', "$contentLength")
-    con.getOutputStream().withCloseable { OutputStream os ->
-      file.newInputStream().withCloseable { InputStream is ->
-        byte[] buf = new byte[16 * 1024]
-        int bytesRead
-        while ((bytesRead = is.read(buf)) != -1) {
-          os.write(buf, 0, bytesRead)
-        }
-        os.flush()
-        project.logger.info("upload complete")
-      }
-    }
+    http.uploadFile(file)
     project.logger.info("Waiting for HTTP response")
-    int httpStatus = con.responseCode
-    project.logger.info("Upload finished with status $httpStatus: ${con.responseMessage}")
-    (httpStatus >= 400 ?
-      con.getErrorStream() :
-      con.getInputStream()).withCloseable { InputStream is ->
-      project.logger.debug("Upload response:\n$is.text")
-    }
-    con.disconnect()
+    def response = http.response
+    project.logger.info("Upload finished with status $response.responseCode: $response.statusLine")
+    project.logger.debug("Upload response:\n$response.responseBody")
   }
 }

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
@@ -24,7 +24,6 @@ class BintrayPublishExtension {
   final Property<String> debDistribution
   final Property<String> debComponent
   final Property<String> debArchitectures
-  final Property<String> debBuildNumber
   final Property<Integer> publishWaitForSecs
 
   BintrayPublishExtension(Project project) {
@@ -41,8 +40,7 @@ class BintrayPublishExtension {
     debDistribution = props.property(String).convention("trusty,xenial,bionic")
     debComponent = props.property(String).convention("spinnaker")
     debArchitectures = props.property(String).convention( "i386,amd64")
-    debBuildNumber = props.property(String)
-    publishWaitForSecs = props.property(Integer)
+    publishWaitForSecs = props.property(Integer).convention(0)
   }
 
   //------------------------------------------------------------------------
@@ -96,6 +94,10 @@ class BintrayPublishExtension {
     return debArchitectures
   }
 
+  Provider<Integer> publishWaitForSecs() {
+    return withSysProp(publishWaitForSecs, Integer, "bintrayPublishWaitForSecs")
+  }
+
   String bintrayUser() {
     return projectProperty(String, "bintrayUser")
   }
@@ -116,7 +118,27 @@ class BintrayPublishExtension {
     return bintrayOrg().flatMap { String org ->
       bintrayJarRepo().flatMap { String repo ->
         bintrayJarPackage().map { String pkg ->
-          "https://api.bintray.com/maven/$org/$repo/$pkg/;publish=1".toString()
+          "https://api.bintray.com/maven/$org/$repo/$pkg/".toString()
+        }
+      }
+    }
+  }
+
+  Provider<String> jarPublishVersionUri() {
+    return bintrayOrg().flatMap { String org ->
+      bintrayJarRepo().flatMap { String repo ->
+        bintrayJarPackage().map { String pkg ->
+          "https://api.bintray.com/content/$org/$repo/$pkg/${project.version}/publish".toString()
+        }
+      }
+    }
+  }
+
+  Provider<String> jarCreateVersionUri() {
+    return bintrayOrg().flatMap { String org ->
+      bintrayJarRepo().flatMap { String repo ->
+        bintrayJarPackage().map { String pkg ->
+          "https://api.bintray.com/packages/$org/$repo/$pkg/versions".toString()
         }
       }
     }

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishPlugin.groovy
@@ -4,6 +4,7 @@ import com.netflix.gradle.plugins.deb.Deb
 import com.netflix.gradle.plugins.packaging.SystemPackagingPlugin
 import com.netflix.spinnaker.gradle.Flags
 import com.netflix.spinnaker.gradle.publishing.PublishingPlugin
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -24,6 +25,32 @@ class BintrayPublishPlugin implements Plugin<Project> {
     }
 
     project.plugins.withType(MavenPublishPlugin) {
+      try {
+        project.rootProject.tasks.register("createBintrayVersion", BintrayCreateVersionTask) {
+          it.createVersionUri = extension.jarCreateVersionUri()
+          it.packageName = extension.bintrayJarPackage()
+          it.bintrayAuthHeader = extension.basicAuthHeader()
+          it.onlyIf { extension.enabled().get() }
+          it.onlyIf { extension.jarEnabled().get() }
+          it.onlyIf { project.version.toString() != Project.DEFAULT_VERSION }
+        }
+      } catch (InvalidUserDataException duplicateTask) {
+        //we need a single top level task to create the version, ignore if another module already configured it
+      }
+
+      try {
+        project.rootProject.tasks.register("publishBintrayVersion", BintrayPublishVersionTask) {
+          it.publishUri = extension.jarPublishVersionUri()
+          it.bintrayAuthHeader = extension.basicAuthHeader()
+          it.publishWaitForSecs = extension.publishWaitForSecs()
+          it.onlyIf { extension.enabled().get() }
+          it.onlyIf { extension.jarEnabled().get() }
+          it.onlyIf { project.version.toString() != Project.DEFAULT_VERSION }
+        }
+      } catch (InvalidUserDataException duplicateTask) {
+        //we need a single top level task to publish the version, ignore if another module already configured it
+      }
+
       project.extensions.configure(PublishingExtension) { publishing ->
         publishing.repositories.maven { MavenArtifactRepository repo ->
           repo.name = 'bintraySpinnaker'
@@ -34,6 +61,8 @@ class BintrayPublishPlugin implements Plugin<Project> {
           }
         }
 
+        def publishVersionTask = project.rootProject.tasks.named("publishBintrayVersion")
+        def createVersionTask = project.rootProject.tasks.named("createBintrayVersion")
 
         project.tasks.matching { Task t ->
           t.name == "publish${PublishingPlugin.PUBLICATION_NAME.capitalize()}PublicationTo${MAVEN_REPO_NAME.capitalize()}Repository"
@@ -41,6 +70,8 @@ class BintrayPublishPlugin implements Plugin<Project> {
           it.onlyIf { extension.enabled().get() }
           it.onlyIf { extension.jarEnabled().get() }
           it.onlyIf { project.version.toString() != Project.DEFAULT_VERSION }
+          it.dependsOn(createVersionTask)
+          it.finalizedBy(publishVersionTask)
         }
       }
     }
@@ -49,6 +80,7 @@ class BintrayPublishPlugin implements Plugin<Project> {
       TaskProvider<Deb> debTask = project.tasks.named("buildDeb", Deb)
       TaskProvider<Task> publishDeb = project.tasks.register("publishDeb", BintrayDebUploadTask) {
           it.archiveFile = debTask.flatMap { it.archiveFile }
+          it.bintrayAuthHeader = extension.basicAuthHeader()
           it.publishUri = extension.debPublishUri(debTask)
           it.dependsOn(debTask)
           it.onlyIf { extension.enabled().get() }

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishVersionTask.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishVersionTask.groovy
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.gradle.publishing.bintray
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+class BintrayPublishVersionTask extends DefaultTask {
+  @Input
+  Provider<String> publishUri
+
+  @Input
+  Provider<Integer> publishWaitForSecs
+
+  @Input
+  String bintrayAuthHeader
+
+  @TaskAction
+  void publishVersion() {
+    def url = publishUri.get()
+    def http = new HttpUtil(url, bintrayAuthHeader, 'POST')
+    String publishVersion = """\
+    {
+      "publish_wait_for_secs": "${publishWaitForSecs.get()}"
+    }
+    """.stripIndent()
+    project.logger.info("POSTing version publish request to $url")
+    http.uploadJson(publishVersion)
+    project.logger.info("Waiting for HTTP response")
+    def response = http.response
+    project.logger.info("Version publish finished with status $response.responseCode: $response.statusLine")
+    project.logger.debug("Version publish response:\n$response.responseBody")
+  }
+}

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/HttpUtil.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/HttpUtil.groovy
@@ -1,0 +1,71 @@
+package com.netflix.spinnaker.gradle.publishing.bintray
+
+class HttpUtil {
+
+  final HttpURLConnection connection
+  Response response
+
+  HttpUtil(String url, String authHeader, String method) {
+    connection = (HttpURLConnection) url.toURL().openConnection()
+    connection.setRequestMethod(method)
+    header("Authorization", authHeader)
+  }
+
+  HttpUtil header(String name, String value) {
+    connection.setRequestProperty(name, value)
+    this
+  }
+
+  HttpUtil uploadFile(File file, String contentType = "application/octet-stream") {
+    upload(file.newInputStream(), contentType, file.size())
+  }
+
+  HttpUtil uploadJson(String json) {
+    byte[] bytes = json.getBytes("UTF-8")
+    upload(new ByteArrayInputStream(bytes), "application/json", bytes.length)
+  }
+
+  HttpUtil upload(InputStream source, String contentType, long size) {
+    connection.setDoOutput(true)
+    header("Content-Length", Long.toString(size))
+    header("Content-Type", contentType)
+    connection.getOutputStream().withCloseable { OutputStream os ->
+      source.withCloseable { InputStream is ->
+        byte[] buf = new byte[16 * 1024]
+        int bytesRead
+        while ((bytesRead = is.read(buf)) != -1) {
+          os.write(buf, 0, bytesRead)
+        }
+        os.flush()
+      }
+    }
+    this
+  }
+
+  Response getResponse() {
+    if (response == null) {
+      int httpStatus = connection.responseCode
+      String message = connection.responseMessage
+      String body = (httpStatus >= 400 ?
+        connection.getErrorStream() :
+        connection.getInputStream()).withCloseable { InputStream is ->
+          is.text
+      }
+      response = new Response(httpStatus, message, body)
+      connection.disconnect()
+    }
+    return response
+  }
+
+  static class Response {
+    final int responseCode
+    final String statusLine
+    final String responseBody
+
+    Response(int responseCode, String statusLine, String responseBody) {
+      this.responseCode = responseCode
+      this.statusLine = statusLine
+      this.responseBody = responseBody
+    }
+  }
+}


### PR DESCRIPTION
Changes the jar publishing lifecycle:
1. create a version in bintray
2. upload all the artifacts
3. issue a publish command

This eliminates some server side race condition in bintray that
will regularly but randomly result in HTTP 409 responses during
jar publishing where the publish is triggered via the repository
URL `;publish=1` matrix parameter