### PR TITLE
fix(AssembleUIPluginTask): restore this.from().into()

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleUIPluginTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleUIPluginTask.kt
@@ -29,6 +29,8 @@ open class AssembleUIPluginTask : Zip() {
     this.archiveVersion.set("")
     this.archiveExtension.set("zip")
 
+    this.from(project.files("${project.buildDir}/dist")).into("/")
+
     project.afterEvaluate {
       dependsOn(project.tasks.getByName("build"))
     }


### PR DESCRIPTION
This reverts a change made in a previous PR.  I misunderstood what this line was doing and this broke bundling of deck plugins.