### PR TITLE
fix(build): add the bintray publish repo as a resolver repo

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
@@ -124,6 +124,14 @@ class BintrayPublishExtension {
     }
   }
 
+  Provider<String> jarMavenRepoUrl() {
+    return bintrayOrg().flatMap { String org ->
+      bintrayJarRepo().map { String repo ->
+        "https://dl.bintray.com/$org/$repo/".toString()
+      }
+    }
+  }
+
   Provider<String> jarPublishVersionUri() {
     return bintrayOrg().flatMap { String org ->
       bintrayJarRepo().flatMap { String repo ->

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishPlugin.groovy
@@ -19,6 +19,18 @@ class BintrayPublishPlugin implements Plugin<Project> {
   void apply(Project project) {
     project.plugins.apply(BasePlugin)
     def extension = project.extensions.create("bintraySpinnaker", BintrayPublishExtension, project)
+
+    project.afterEvaluate {
+      if (extension.enabled().get() && extension.jarEnabled().get()) {
+        def bintraySpinnaker = project.repositories.maven {
+          it.name = 'bintraySpinnakerRepo'
+          it.url = extension.jarMavenRepoUrl()
+        }
+        project.repositories.remove(bintraySpinnaker)
+        project.repositories.addFirst(bintraySpinnaker)
+      }
+    }
+
     if (!extension.hasCreds()) {
       project.logger.info("Not configuring bintray publishing, ensure bintrayUser and bintrayKey project properties are set")
       return


### PR DESCRIPTION
This used to happen prior to refactoring things, and I suspect is the reason we see 10 minute dependency times is that
we are currently waiting to see the dependencies sync all the way to jcenter