### PR TITLE
fix(version): set the Implementation-Version in MANIFEST.MF

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtensio
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
 import groovy.json.JsonOutput
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -80,7 +81,7 @@ open class CreatePluginInfoTask : DefaultTask() {
   }
 
   private fun isVersionSpecified(version: String): Boolean {
-    return version.isNotBlank() && version.isNotEmpty() && version != "unspecified"
+    return version.isNotBlank() && version != Project.DEFAULT_VERSION
   }
 
   private fun getChecksum(): String {

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -46,7 +46,7 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
     }
 
   private static void setImplementationVersion(Jar jar, Project project) {
-    def version = project.getVersion()
+    def version = project.findProperty("ossVersion") ?: project.getVersion()
     if (version != Project.DEFAULT_VERSION) {
       jar.manifest {
         (it as Manifest).attributes(["Implementation-Version": version.toString()])

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.gradle.baseproject
 
-import com.netflix.spinnaker.gradle.Flags
+
 import groovy.transform.CompileStatic
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -37,7 +37,7 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
       // Nebula insists on building Javadoc, but we don't do anything with it
       // and it seems to cause lots of errors.
       project.tasks.withType(Javadoc) { (it as Javadoc).setFailOnError(false) }
-      project.tasks.withType(Jar) { setImplementationOssVersion((it as Jar), project) }
+      project.tasks.withType(Jar) { setImplementationVersion((it as Jar), project) }
 
       project.plugins.withType(BasePlugin) {
         Delete clean = project.getTasks().getByName(BasePlugin.CLEAN_TASK_NAME) as Delete
@@ -45,19 +45,12 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
       }
     }
 
-  /**
-   * If the property "ossVersion" exists the MANIFEST.MF "Implementation-Version" attribute
-   * will be set to the corresponding property. This can be used to support use cases where services
-   * are being extended and rebuilt.  Unless you're re-building services, this is likely unnecessary
-   * and the default value of the attribute "Implementation-Version" will suffice for determining
-   * the service version.
-   */
-    private static void setImplementationOssVersion(Jar jar, Project project) {
-      String ossVersionProperty = "ossVersion"
-      if (project.hasProperty(ossVersionProperty)) {
-        jar.manifest {
-          (it as Manifest).attributes(["Implementation-Version": project.property(ossVersionProperty)])
-        }
+  private static void setImplementationVersion(Jar jar, Project project) {
+    def version = project.getVersion()
+    if (version != Project.DEFAULT_VERSION) {
+      jar.manifest {
+        (it as Manifest).attributes(["Implementation-Version": version.toString()])
       }
     }
+  }
 }


### PR DESCRIPTION
This (along with everything else in `MANIFEST.MF`) got lost when we stopped using Nebula. Halyard was depending on it, so let's put it back.

This fixes part of spinnaker/spinnaker#5740.