### PR TITLE
fix(manifest): Avoid remove plugin data on manifest

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/Plugins.kt
@@ -25,6 +25,7 @@ object Plugins {
   const val RELEASE_BUNDLE_TASK_NAME = "releaseBundle"
   const val CHECKSUM_BUNDLE_TASK_NAME = "checksumBundle"
   const val COLLECT_PLUGIN_ZIPS_TASK_NAME = "collectPluginZips"
+  const val ADD_PLUGIN_DATA_TO_MANIFEST = "addPluginDataToManifest"
 
   internal fun hasDeckPlugin(project: Project): Boolean =
     project.rootProject.subprojects.any { it.plugins.hasPlugin(SpinnakerUIExtensionPlugin::class.java) }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -43,10 +43,12 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     project.extensions.create("spinnakerPlugin", SpinnakerPluginExtension::class.java)
     project.tasks.register(ASSEMBLE_PLUGIN_TASK_NAME, AssembleJavaPluginZipTask::class.java)
 
-    project.tasks.getByName("jar")
-      .doFirst {
-        (it as Jar).createPluginManifest(project)
+    project.tasks.create(Plugins.ADD_PLUGIN_DATA_TO_MANIFEST) {
+      it.doLast {
+        (project.tasks.getByName("jar") as Jar).createPluginManifest(project)
       }
+    }
+    project.tasks.getByName("jar").dependsOn(Plugins.ADD_PLUGIN_DATA_TO_MANIFEST)
   }
 
   private fun Jar.createPluginManifest(project: Project) {


### PR DESCRIPTION
**Issue Description**
When you run `./gradlew releaseBundle` it generates the `MANIFEST.MF` file under `build/tmp/jar` and it contains information about the plugin. But if you run any other `gradle` task that involves a build task (ex. `"jar" `task), the plugin information in the `MANIFEST.MF` is removed.

**How to reproduce it**
Run `./gradlew clean releaseBundle `, it will generate the plugin info in the `MANIFEST.MF`. After doing that, run `./gradlew build`  it will remove the plugin info from the `MANIFEST.MF.`

To fix it, i just created a separated task following https://guides.gradle.org/using-build-cache/#suggestions_for_authoring_your_build

