### PR TITLE
chore(formatting): upgrade spotless, ktlint, and google-java-format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.diffplug.gradle.spotless" version "3.29.0" apply false
+  id "com.diffplug.spotless" version "5.1.0" apply false
   id "com.gradle.plugin-publish" version "0.12.0" apply false
 }
 
@@ -8,7 +8,7 @@ subprojects {
     gradlePluginPortal()
   }
 
-  apply plugin: 'com.diffplug.gradle.spotless'
+  apply plugin: 'com.diffplug.spotless'
   apply plugin: 'groovy'
   apply plugin: 'idea'
   apply plugin: 'java-gradle-plugin'

--- a/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-project-plugin/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   implementation 'com.github.jk1:gradle-license-report:1.8'
   implementation 'org.owasp:dependency-check-gradle:5.1.0'
-  implementation "com.diffplug.spotless:spotless-plugin-gradle:3.27.2"
+  implementation "com.diffplug.spotless:spotless-plugin-gradle:5.1.0"
   implementation 'org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r'
   implementation 'com.netflix.nebula:gradle-java-cross-compile-plugin:4.1.0'
   implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'


### PR DESCRIPTION
There are some minor formatting changes that will need to be applied to each project now. I'll probably kill the bumpdeps action so I can do those manually.