### PR TITLE
feat(javac): add a `targetJava11` project property

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/Flags.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/Flags.groovy
@@ -5,6 +5,13 @@ import org.gradle.api.Project
 class Flags {
 
   /**
+   * Whether or not the {@code targetJava11} property was set.
+   */
+  static boolean targetJava11(Project project) {
+    return Boolean.valueOf(project.findProperty("targetJava11")?.toString())
+  }
+
+  /**
    * Whether cross-compilation should be enabled.
    *
    * Determined by the project property 'enableCrossCompilerPlugin', and

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.gradle.baseproject
 
-
+import com.netflix.spinnaker.gradle.Flags
 import groovy.transform.CompileStatic
 import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
@@ -19,12 +19,13 @@ import org.gradle.jvm.tasks.Jar
 class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
+      def javaVersion = Flags.targetJava11(project) ? JavaVersion.VERSION_11 : JavaVersion.VERSION_1_8
       project.plugins.withType(JavaBasePlugin) {
         project.plugins.apply(MavenPublishPlugin)
         project.repositories.jcenter()
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)
-        convention.sourceCompatibility = JavaVersion.VERSION_1_8
-        convention.targetCompatibility = JavaVersion.VERSION_1_8
+        convention.sourceCompatibility = javaVersion
+        convention.targetCompatibility = javaVersion
       }
       project.plugins.withType(JavaLibraryPlugin) {
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)


### PR DESCRIPTION
If set, we'll use `-source 11 -target 11` instead of `1.8`. Now that Netflix is moving to the Java 11 runtime, we can start using Java 11 language features. So I'll start migrating all the microservices.