### PR TITLE
fix(manifest): include rootProject version when the extension version is unspecified

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -60,11 +60,11 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
 
     val attributes = mutableMapOf<String, String>()
 
-    val rootProjectVersion = removeTagPrefix(project.rootProject.version.toString())
+    val pluginVersion = removeTagPrefix(bundleExt.version, project)
 
     applyAttributeIfSet(attributes, "Plugin-Class", pluginExt.pluginClass)
     applyAttributeIfSet(attributes, "Plugin-Id", bundleExt.pluginId)
-    applyAttributeIfSet(attributes, "Plugin-Version", if (isVersionSpecified(bundleExt.version)) bundleExt.version else rootProjectVersion)
+    applyAttributeIfSet(attributes, "Plugin-Version", pluginVersion)
     applyAttributeIfSet(attributes, "Plugin-Dependencies", pluginExt.dependencies)
     applyAttributeIfSet(attributes, "Plugin-Requires", pluginExt.requires)
     applyAttributeIfSet(attributes, "Plugin-Description", bundleExt.description)
@@ -106,11 +106,9 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
   }
 
   //the plugin version is supplied with a v from tag, but fails when update manager compares versions
-  private fun removeTagPrefix(version: String): String {
-    if (version.startsWith("v")) {
-      return version.removePrefix("v")
-    }
-    return version
+  private fun removeTagPrefix(bundleVersion: String, project: Project): String {
+    val version = if (isVersionSpecified(bundleVersion)) bundleVersion else project.rootProject.version.toString()
+    return version.removePrefix("v")
   }
 
   private fun isVersionSpecified(version: String): Boolean {

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -60,9 +60,11 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
 
     val attributes = mutableMapOf<String, String>()
 
+    val rootProjectVersion = removeTagPrefix(project.rootProject.version.toString())
+
     applyAttributeIfSet(attributes, "Plugin-Class", pluginExt.pluginClass)
     applyAttributeIfSet(attributes, "Plugin-Id", bundleExt.pluginId)
-    applyAttributeIfSet(attributes, "Plugin-Version", bundleExt.version)
+    applyAttributeIfSet(attributes, "Plugin-Version", if (isVersionSpecified(bundleExt.version)) bundleExt.version else rootProjectVersion)
     applyAttributeIfSet(attributes, "Plugin-Dependencies", pluginExt.dependencies)
     applyAttributeIfSet(attributes, "Plugin-Requires", pluginExt.requires)
     applyAttributeIfSet(attributes, "Plugin-Description", bundleExt.description)
@@ -101,5 +103,17 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     if (value != null) {
       attributes[key] = value
     }
+  }
+
+  //the plugin version is supplied with a v from tag, but fails when update manager compares versions
+  private fun removeTagPrefix(version: String): String {
+    if (version.startsWith("v")) {
+      return version.removePrefix("v")
+    }
+    return version
+  }
+
+  private fun isVersionSpecified(version: String): Boolean {
+    return version.isNotBlank() && version != Project.DEFAULT_VERSION
   }
 }


### PR DESCRIPTION
This PR ensure that a version is included in the MANIFEST.

In some plugins, the value of the plugin bundler extension is set as `unspecified` so kork project is not able to compare version correctly.

I made these changes following the implementation to create `plugin-info.json` here: https://github.com/spinnaker/spinnaker-gradle-project/blob/ec00e146cb66d03f69b4f9bcae5c6cc7a437a485/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt#L68