### PR TITLE
feat(plugins): add compatibility test runner

### DIFF
--- a/spinnaker-extensions/build.gradle.kts
+++ b/spinnaker-extensions/build.gradle.kts
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-
 plugins {
   // Apply the Kotlin JVM plugin to add support for Kotlin.
-  id("org.jetbrains.kotlin.jvm").version("1.3.31")
+  id("org.jetbrains.kotlin.jvm").version("1.3.72")
+  `kotlin-dsl`
 }
 
 dependencies {
   implementation("org.gradle.crypto.checksum:org.gradle.crypto.checksum.gradle.plugin:1.2.0")
+
+  implementation(platform("com.fasterxml.jackson:jackson-bom:2.11.1"))
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api")
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin")
 
   // Kotlin JDK 8 standard library.
   implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
@@ -50,6 +56,11 @@ gradlePlugin {
       id = "io.spinnaker.plugin.bundler"
       implementationClass = "com.netflix.spinnaker.gradle.extension.SpinnakerExtensionsBundlerPlugin"
     }
+
+    create("compatibilityTestRunner") {
+      id = "io.spinnaker.plugin.compatibility-test-runner"
+      implementationClass = "com.netflix.spinnaker.gradle.extension.SpinnakerCompatibilityTestRunnerPlugin"
+    }
   }
 }
 
@@ -70,6 +81,10 @@ pluginBundle {
 
     "bundler" {
       displayName = "Spinnaker extension bundler plugin"
+    }
+
+    "compatibilityTestRunner" {
+      displayName = "Spinnaker compatibility test runner"
     }
   }
 }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPlugin.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.extension
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtension
+import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
+import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.*
+import java.lang.IllegalStateException
+import java.net.URL
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+class SpinnakerCompatibilityTestRunnerPlugin : Plugin<Project> {
+
+  private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+
+  override fun apply(project: Project) {
+    project.plugins.apply(JavaPlugin::class.java)
+    project.plugins.apply(KotlinPluginWrapper::class.java)
+
+    val bundle = project.rootProject.extensions.getByType(SpinnakerBundleExtension::class)
+    bundle.compatibility.spinnaker.forEach { v ->
+      val sourceSet = "compatibility-$v"
+      val configuration = "${sourceSet}Implementation"
+
+      project.configurations.create(configuration).extendsFrom(project.configurations.getByName("${SourceSet.TEST_SOURCE_SET_NAME}Implementation"))
+
+      project.sourceSets.create(sourceSet) {
+        compileClasspath += project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
+        runtimeClasspath += project.sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
+
+        project.sourceSets.getByName(SourceSet.TEST_SOURCE_SET_NAME).also { test ->
+          java.srcDirs(test.java.srcDirs)
+          kotlin.srcDirs(test.kotlin.srcDirs)
+          resources.srcDirs(test.resources.srcDirs)
+        }
+      }
+
+      project.tasks.register<Test>("compatibilityTest-${project.name}-$v") {
+        description = "Runs compatibility tests for Spinnaker $v"
+        group = GROUP
+        testClassesDirs = project.sourceSets.getByName(sourceSet).output.classesDirs
+        classpath = project.sourceSets.getByName(sourceSet).runtimeClasspath
+      }
+
+      // Gradle hasn't seen the `SpinnakerPluginExtension` DSL values yet,
+      // so push this last step into a lifecycle hook.
+      project.afterEvaluate {
+        val plugin = project.extensions.getByType(SpinnakerPluginExtension::class)
+        val resolvedServiceVersion = URL("${bundle.compatibility.halconfigBaseURL}/bom/${v}.yml").openStream().use {
+          mapper.readValue<HalyardBOM>(it).services[plugin.serviceName]?.version ?: throw IllegalStateException("Could not find version for service ${plugin.serviceName}")
+        }
+
+        project.dependencies.platform("com.netflix.spinnaker.${plugin.serviceName}:${plugin.serviceName}-bom:$resolvedServiceVersion").apply {
+          force = true
+        }.also {
+          project.dependencies.add(configuration, it)
+        }
+
+        // Copy the kotlin test compilation options into the generated compile tasks.
+        project.compileKotlinTask("compileTestKotlin")?.also { compileTestKt ->
+          project.compileKotlinTask("compileCompatibility-${v}Kotlin")?.apply {
+            kotlinOptions {
+              languageVersion = compileTestKt.kotlinOptions.languageVersion
+              jvmTarget = compileTestKt.kotlinOptions.jvmTarget
+            }
+          } ?: throw IllegalStateException("Could not find compileKotlin task for source set $sourceSet")
+        }
+      }
+    }
+
+    project.rootProject.tasks.maybeCreate(TASK_NAME).apply {
+      description = "Runs Spinnaker compatibility tests"
+      group = GROUP
+      dependsOn(bundle.compatibility.spinnaker.map { ":${project.name}:compatibilityTest-${project.name}-$it" })
+    }
+  }
+
+  companion object {
+    const val TASK_NAME = "compatibilityTest"
+    const val GROUP = "Spinnaker Compatibility"
+  }
+}
+
+internal val Project.sourceSets: SourceSetContainer
+  get() = project.convention.getPlugin(JavaPluginConvention::class.java).sourceSets
+
+internal var Dependency.force: Boolean
+  get() = withGroovyBuilder { getProperty("force") as Boolean }
+  set(value) = withGroovyBuilder { "force"(value) }
+
+private val SourceSet.kotlin: SourceDirectorySet
+  get() = withConvention(KotlinSourceSet::class) { kotlin }
+
+private fun Project.compileKotlinTask(task: String): KotlinCompile? =
+  tasks.findByName(task) as KotlinCompile?
+
+data class HalyardBOM(
+  val services: Map<String, ServiceVersion>
+)
+
+data class ServiceVersion(
+  val version: String?
+)

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionsBundlerPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionsBundlerPlugin.kt
@@ -22,14 +22,10 @@ import com.netflix.spinnaker.gradle.extension.Plugins.CHECKSUM_BUNDLE_TASK_NAME
 import com.netflix.spinnaker.gradle.extension.Plugins.COLLECT_PLUGIN_ZIPS_TASK_NAME
 import com.netflix.spinnaker.gradle.extension.Plugins.RELEASE_BUNDLE_TASK_NAME
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtension
-import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
-import com.netflix.spinnaker.gradle.extension.tasks.BundlePluginsTask
 import com.netflix.spinnaker.gradle.extension.tasks.CreatePluginInfoTask
-import org.gradle.api.AntBuilder
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
-import org.gradle.api.logging.LogLevel
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.bundling.Zip
@@ -50,13 +46,13 @@ class SpinnakerExtensionsBundlerPlugin : Plugin<Project> {
 
     project.tasks.register(COLLECT_PLUGIN_ZIPS_TASK_NAME, Copy::class.java) {
 
-      it.group = Plugins.GROUP
+      group = Plugins.GROUP
 
       // Look for assemblePlugin task.
-      if (it.project.subprojects.isNotEmpty()) { // Safe guard this in case if project structure is not set correctly.
-        val assemblePluginTasks: Set<Task> = it.project.getTasksByName(ASSEMBLE_PLUGIN_TASK_NAME, true)
+      if (project.subprojects.isNotEmpty()) { // Safe guard this in case if project structure is not set correctly.
+        val assemblePluginTasks: Set<Task> = project.getTasksByName(ASSEMBLE_PLUGIN_TASK_NAME, true)
         if (assemblePluginTasks.isNotEmpty()) {
-          it.dependsOn(assemblePluginTasks)
+          dependsOn(assemblePluginTasks)
         }
       }
 
@@ -67,28 +63,28 @@ class SpinnakerExtensionsBundlerPlugin : Plugin<Project> {
         }
         .map { subproject -> project.file("${subproject.buildDir}/distributions") }
 
-      it.from(distributions)
+      from(distributions)
         .into("${project.buildDir}/zips")
     }
 
     project.tasks.register(BUNDLE_PLUGINS_TASK_NAME, Zip::class.java) {
-      it.dependsOn(COLLECT_PLUGIN_ZIPS_TASK_NAME)
-      it.group = Plugins.GROUP
-      it.from("${project.buildDir}/zips")
+      dependsOn(COLLECT_PLUGIN_ZIPS_TASK_NAME)
+      group = Plugins.GROUP
+      from("${project.buildDir}/zips")
     }
 
     project.tasks.register(CHECKSUM_BUNDLE_TASK_NAME, Checksum::class.java) {
-      it.dependsOn(BUNDLE_PLUGINS_TASK_NAME)
-      it.group = Plugins.GROUP
+      dependsOn(BUNDLE_PLUGINS_TASK_NAME)
+      group = Plugins.GROUP
 
-      it.files = project.tasks.getByName(BUNDLE_PLUGINS_TASK_NAME).outputs.files
-      it.outputDir = File(project.buildDir, "checksums")
-      it.algorithm = Checksum.Algorithm.SHA512
+      files = project.tasks.getByName(BUNDLE_PLUGINS_TASK_NAME).outputs.files
+      outputDir = File(project.buildDir, "checksums")
+      algorithm = Checksum.Algorithm.SHA512
     }
 
     project.tasks.register(RELEASE_BUNDLE_TASK_NAME, CreatePluginInfoTask::class.java) {
-      it.dependsOn(CHECKSUM_BUNDLE_TASK_NAME)
-      it.group = Plugins.GROUP
+      dependsOn(CHECKSUM_BUNDLE_TASK_NAME)
+      group = Plugins.GROUP
     }
   }
 }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerServiceExtensionPlugin.kt
@@ -44,7 +44,7 @@ class SpinnakerServiceExtensionPlugin : Plugin<Project> {
     project.tasks.register(ASSEMBLE_PLUGIN_TASK_NAME, AssembleJavaPluginZipTask::class.java)
 
     project.tasks.create(Plugins.ADD_PLUGIN_DATA_TO_MANIFEST) {
-      it.doLast {
+      doLast {
         (project.tasks.getByName("jar") as Jar).createPluginManifest(project)
       }
     }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
@@ -38,15 +38,15 @@ class SpinnakerUIExtensionPlugin : Plugin<Project> {
     project.tasks.create(ASSEMBLE_PLUGIN_TASK_NAME, AssembleUIPluginTask::class.java)
 
     project.tasks.create("yarn", Exec::class.java) {
-      it.group = Plugins.GROUP
-      it.workingDir = project.projectDir
-      it.commandLine = listOf("yarn")
+      group = Plugins.GROUP
+      workingDir = project.projectDir
+      commandLine = listOf("yarn")
     }
 
     project.tasks.create("yarnBuild", Exec::class.java) {
-      it.group = Plugins.GROUP
-      it.workingDir = project.projectDir
-      it.commandLine = listOf("yarn", "build")
+      group = Plugins.GROUP
+      workingDir = project.projectDir
+      commandLine = listOf("yarn", "build")
     }
 
     project.afterEvaluate {

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerBundleExtension.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerBundleExtension.kt
@@ -15,6 +15,9 @@
  */
 package com.netflix.spinnaker.gradle.extension.extensions
 
+import org.gradle.api.Action
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.create
 import java.lang.IllegalStateException
 
 /**
@@ -77,5 +80,44 @@ open class SpinnakerBundleExtension {
       throw IllegalStateException("spinnakerBundle.$name must not be null")
     }
     return value
+  }
+
+  /**
+   * An extension block that describes a plugin's compatibility.
+   */
+  val compatibility
+    get() = (this as ExtensionAware).extensions.getByName(SpinnakerCompatibilityExtension.NAME) as SpinnakerCompatibilityExtension
+
+  // For Kotlin build scripts.
+  fun compatibility(configure: SpinnakerCompatibilityExtension.() -> Unit) =
+    (this as ExtensionAware).also {
+      it.extensions.create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
+      it.extensions.configure(SpinnakerCompatibilityExtension.NAME, configure)
+    }
+
+  // For Groovy build scripts.
+  fun compatibility(configure: Action<SpinnakerCompatibilityExtension>) =
+    (this as ExtensionAware).also {
+      it.extensions.create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
+      it.extensions.configure(SpinnakerCompatibilityExtension.NAME, configure)
+    }
+
+  open class SpinnakerCompatibilityExtension {
+    /**
+     * A list of top-level Spinnaker versions (e.g., 1.21.0, 1.22.0) that this plugin is compatible with.
+     */
+    var spinnaker: List<String>
+      set(value) {
+        _spinnaker = value
+      }
+      get() = _spinnaker ?: throw IllegalStateException("spinnakerBundle.compatibility.spinnaker must not be null")
+
+    private var _spinnaker: List<String>? = null
+
+    var halconfigBaseURL: String = "https://storage.googleapis.com/halconfig"
+
+    companion object {
+      const val NAME = "compatibility"
+    }
   }
 }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleJavaPluginZipTask.kt
@@ -30,7 +30,7 @@ import java.lang.IllegalStateException
 open class AssembleJavaPluginZipTask : Zip() {
 
   @Internal
-  override fun getGroup(): String? = Plugins.GROUP
+  override fun getGroup(): String = Plugins.GROUP
 
   init {
     val ext = project.extensions.findByType(SpinnakerPluginExtension::class.java)

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleUIPluginTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/AssembleUIPluginTask.kt
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.bundling.Zip
 open class AssembleUIPluginTask : Zip() {
 
   @Internal
-  override fun getGroup(): String? = Plugins.GROUP
+  override fun getGroup(): String = Plugins.GROUP
 
   init {
     this.archiveBaseName.set("deck")

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/BundlePluginsTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/BundlePluginsTask.kt
@@ -26,7 +26,7 @@ import org.gradle.api.tasks.bundling.Zip
 open class BundlePluginsTask : Zip() {
 
   @Internal
-  override fun getGroup(): String? = Plugins.GROUP
+  override fun getGroup(): String = Plugins.GROUP
 
   init {
     project.afterEvaluate {

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/CreatePluginInfoTask.kt
@@ -34,7 +34,7 @@ import java.time.Instant
 open class CreatePluginInfoTask : DefaultTask() {
 
   @Internal
-  override fun getGroup(): String? = Plugins.GROUP
+  override fun getGroup(): String = Plugins.GROUP
 
   @Internal
   val rootProjectVersion: String = project.rootProject.version.toString()

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/RegistrationTask.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/tasks/RegistrationTask.kt
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.TaskAction
 open class RegistrationTask : DefaultTask() {
 
   @Internal
-  override fun getGroup(): String? = Plugins.GROUP
+  override fun getGroup(): String = Plugins.GROUP
 
   @TaskAction
   fun doAction() {

--- a/spinnaker-extensions/src/main/resources/META-INF/gradle-plugins/io.spinnaker.plugin.compatibility-test-runner.properties
+++ b/spinnaker-extensions/src/main/resources/META-INF/gradle-plugins/io.spinnaker.plugin.compatibility-test-runner.properties
@@ -1,0 +1,1 @@
+implementation-class=com.netflix.spinnaker.gradle.extension.SpinnakerCompatibilityTestRunnerPlugin

--- a/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginTest.kt
+++ b/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginTest.kt
@@ -17,8 +17,14 @@ package com.netflix.spinnaker.gradle.extension
 
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtension
 import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withGroovyBuilder
 import org.gradle.testfixtures.ProjectBuilder
+import java.net.InetSocketAddress
+import org.gradle.api.tasks.testing.Test as GradleTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 
 /**
@@ -79,4 +85,101 @@ class SpinnakerExtensionGradlePluginTest {
     assertNotNull(project.tasks.findByName(Plugins.COLLECT_PLUGIN_ZIPS_TASK_NAME))
   }
 
+  @Test
+  fun `compatibility-test-runner plugin registers tasks, source sets, and configurations`() {
+    val service = "orca"
+    val compatibility = listOf("1.21.1", "1.22.0")
+
+    // Configure bundler plugin in root project.
+    val rootProject = ProjectBuilder.builder().build()
+    rootProject.plugins.apply("io.spinnaker.plugin.bundler")
+    rootProject.extensions.getByType(SpinnakerBundleExtension::class.java).apply {
+      compatibility {
+        spinnaker = compatibility
+      }
+    }
+
+    // Configure test runner and Spinnaker extension plugins.
+    val subproject = ProjectBuilder.builder().withName("$service-plugin").withParent(rootProject).build()
+    subproject.plugins.apply("io.spinnaker.plugin.compatibility-test-runner")
+    subproject.plugins.apply("io.spinnaker.plugin.service-extension")
+    subproject.extensions.getByType(SpinnakerPluginExtension::class.java).apply {
+      serviceName = service
+    }
+
+    // Verify tasks, source sets, and configurations exist.
+    assertNotNull(rootProject.tasks.findByName(SpinnakerCompatibilityTestRunnerPlugin.TASK_NAME))
+    compatibility.forEach {
+      subproject.tasks.findByName("${SpinnakerCompatibilityTestRunnerPlugin.TASK_NAME}-orca-plugin-${it}").also { task ->
+        assertNotNull(task)
+        assert(task is GradleTest) {
+          "expected generated task to be of type Test"
+        }
+      }
+      assertNotNull(subproject.sourceSets.findByName("compatibility-${it}"))
+      assertNotNull(subproject.configurations.findByName("compatibility-${it}Implementation"))
+    }
+  }
+
+  @Test
+  fun `compatibility-test-runner sets service Gradle BOM version using Halyard BOM`() {
+    val service = "orca"
+    val compatibility = listOf("1.21.1", "1.22.0")
+
+    // Set up bom server.
+    val halconfigServer = HttpServer.create(InetSocketAddress(0), 0).apply {
+      compatibility.forEach { version ->
+        createContext("/bom/${version}.yml") {
+          it.responseHeaders.set("Content-Type", "application/x-yaml")
+          it.sendResponseHeaders(200, 0)
+          it.responseBody.write("""
+            version: "$version"
+            services:
+              ${service}:
+                version: "google-service-version-${version}"
+          """.trimIndent().toByteArray())
+          it.responseBody.close()
+        }
+      }
+      start()
+    }
+
+    // Configure bundler plugin in root project.
+    val rootProject = ProjectBuilder.builder().build()
+    rootProject.plugins.apply("io.spinnaker.plugin.bundler")
+
+    rootProject.extensions.getByType(SpinnakerBundleExtension::class.java).apply {
+      compatibility {
+        spinnaker = compatibility
+        halconfigBaseURL = "http://localhost:${halconfigServer.address.port}"
+      }
+    }
+
+    // Configure test runner and Spinnaker extension plugins.
+    val subproject = ProjectBuilder.builder().withName("$service-plugin").withParent(rootProject).build()
+    subproject.plugins.apply("io.spinnaker.plugin.compatibility-test-runner")
+    subproject.plugins.apply("io.spinnaker.plugin.service-extension")
+    subproject.extensions.getByType(SpinnakerPluginExtension::class.java).apply {
+      serviceName = service
+    }
+
+    // Trigger lifecycle hooks.
+    subproject.evaluate()
+
+    compatibility.forEach { version ->
+      val configuration = subproject.configurations.findByName("compatibility-${version}Implementation")
+      assertNotNull(configuration)
+
+      val bom = configuration.dependencies.find { dependency ->
+        dependency.group == "com.netflix.spinnaker.${service}" && dependency.name == "$service-bom"
+      }
+      assertNotNull(bom)
+      assertEquals("google-service-version-${version}", bom.version)
+      assert(bom.force) {
+        "expected gradle BOM dependency version to be forced"
+      }
+    }
+  }
 }
+
+private fun Project.evaluate() = withGroovyBuilder { "evaluate"() }


### PR DESCRIPTION
This change is (hopefully) well described in the readme. 

The problem we're trying to solve is that plugin developers don't know which top-level Spinnaker versions their plugin is compatible with. We think plugin developers should be writing Spring Boot-style integration tests that load their plugin inside of a service, and then testing across a range of service versions. This plugin helps with the second half of that problem. 