### PR TITLE
feat(tests): allow version aliases in compatibility block

### DIFF
--- a/spinnaker-extensions/README.md
+++ b/spinnaker-extensions/README.md
@@ -100,6 +100,12 @@ The test runner dynamically creates Gradle source sets for each top-level Spinna
 depend on the service Gradle platform version (e.g., `com.spinnaker.netflix.orca:orca-bom`) that corresponds to those Spinnaker versions.
 It does _not_ alter your plugin's compile or runtime classpaths. Your plugin compiles against version `X`; the test runner runs your plugin inside Spinnaker `Y` and `Z`.
 
+Instead of providing an explicit version, you can also supply any of the following aliases:
+
+- `latest`: the most recent Spinnaker release
+- `supported`: the last three Spinnaker releases
+- `nightly`: Spinnaker's nightly build
+
 ### Notes
 
 * Expects multi-project gradle builds where each sub project implements extensions targeting a single spinnaker service.

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerVersionsClient.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerVersionsClient.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.extension
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
+import java.lang.IllegalArgumentException
+import java.net.URL
+
+class DefaultSpinnakerVersionsClient(private val baseURL: String) : SpinnakerVersionsClient {
+
+  private val mapper = ObjectMapper(YAMLFactory()).registerModule(KotlinModule()).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+
+  override fun getSpinnakerBOM(version: String): SpinnakerBOM =
+    URL("$baseURL/bom/$version.yml").openStream().use {
+      mapper.readValue(it)
+    }
+
+  override fun getVersionsManifest(): SpinnakerVersionsManifest =
+    URL("$baseURL/versions.yml").openStream().use {
+      mapper.readValue(it)
+    }
+}
+
+interface SpinnakerVersionsClient {
+  fun getSpinnakerBOM(version: String): SpinnakerBOM
+  fun getVersionsManifest(): SpinnakerVersionsManifest
+}
+
+enum class SpinnakerVersionAlias {
+  LATEST, SUPPORTED, NIGHTLY;
+
+  companion object {
+    fun from(str: String) = try { valueOf(str.toUpperCase()) } catch (iae: IllegalArgumentException) { null }
+    fun isAlias(str: String) = values().any { from(str) != null }
+  }
+}
+
+data class SpinnakerVersionsManifest(val latestSpinnaker: String, val versions: List<SpinnakerVersion>)
+data class SpinnakerVersion(val version: String)
+
+data class SpinnakerBOM(val services: Map<String, ServiceVersion>)
+data class ServiceVersion(val version: String?)

--- a/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPluginTest.kt
+++ b/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPluginTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.netflix.spinnaker.gradle.extension
+
+import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerBundleExtension
+import com.netflix.spinnaker.gradle.extension.extensions.SpinnakerPluginExtension
+import com.sun.net.httpserver.HttpServer
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.withGroovyBuilder
+import org.gradle.api.tasks.testing.Test as GradleTestTask
+import org.gradle.testfixtures.ProjectBuilder
+import java.lang.IllegalStateException
+import java.net.InetSocketAddress
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.Test
+
+/**
+ * Unit tests for the compatibility test runner plugin.
+ * */
+class SpinnakerCompatibilityTestRunnerPluginTest {
+
+  @Test
+  fun `compatibility-test-runner plugin registers tasks, source sets, and configurations`() {
+    val service = "orca"
+    val compatibility = listOf("1.21.1", "1.22.0")
+
+    val (rootProject, subproject) = withProjects {
+      rootProject {
+        plugins.apply("io.spinnaker.plugin.bundler")
+        spinnakerBundle {
+          compatibility {
+            spinnaker = compatibility
+          }
+        }
+      }
+      subproject("$service-plugin") {
+        plugins.apply("io.spinnaker.plugin.compatibility-test-runner")
+        plugins.apply("io.spinnaker.plugin.service-extension")
+        spinnakerPlugin {
+          serviceName = service
+        }
+      }
+    }
+
+    // Verify tasks, source sets, and configurations exist.
+    assertNotNull(rootProject.tasks.findByName(SpinnakerCompatibilityTestRunnerPlugin.TASK_NAME))
+    compatibility.forEach {
+      subproject.tasks.findByName("${SpinnakerCompatibilityTestRunnerPlugin.TASK_NAME}-$service-plugin-$it").also { task ->
+        assertNotNull(task)
+        assert(task is GradleTestTask)
+      }
+      assertNotNull(subproject.sourceSets.findByName("compatibility-$it"))
+      assertNotNull(subproject.configurations.findByName("compatibility-${it}Implementation"))
+    }
+  }
+
+  @Test
+  fun `compatibility-test-runner sets service Gradle BOM version using Halyard BOM`() {
+    val service = "orca"
+    val compatibility = listOf("1.21.1", "1.22.0")
+
+    // Set up bom server.
+    val halconfigServer = HttpServer.create(InetSocketAddress(0), 0).apply {
+      compatibility.forEach { version ->
+        createContext("/bom/${version}.yml") {
+          it.responseHeaders.set("Content-Type", "application/x-yaml")
+          it.sendResponseHeaders(200, 0)
+          it.responseBody.write("""
+            version: "$version"
+            services:
+              ${service}:
+                version: "google-service-version-${version}"
+          """.trimIndent().toByteArray())
+          it.responseBody.close()
+        }
+      }
+      start()
+    }
+
+    val (_, subproject) = withProjects {
+      rootProject {
+        plugins.apply("io.spinnaker.plugin.bundler")
+        spinnakerBundle {
+          compatibility {
+            spinnaker = compatibility
+            halconfigBaseURL = "http://localhost:${halconfigServer.address.port}"
+          }
+        }
+      }
+      subproject("$service-plugin") {
+        plugins.apply("io.spinnaker.plugin.compatibility-test-runner")
+        plugins.apply("io.spinnaker.plugin.service-extension")
+        spinnakerPlugin {
+          serviceName = service
+        }
+      }
+    }
+
+    // Trigger lifecycle hooks.
+    subproject.evaluate()
+
+    compatibility.forEach { version ->
+      val configuration = subproject.configurations.findByName("compatibility-${version}Implementation")
+      assertNotNull(configuration)
+
+      val bom = configuration.dependencies.find { dependency ->
+        dependency.group == "com.netflix.spinnaker.${service}" && dependency.name == "$service-bom"
+      }
+      assertNotNull(bom)
+      assertEquals("google-service-version-${version}", bom.version)
+      assert(bom.force) { "expected gradle BOM dependency version to be forced" }
+    }
+  }
+
+  @Test
+  fun `compatibility-test-runner resolves version aliases`() {
+    val service = "orca"
+    val compatibility = listOf("supported", "latest", "nightly", "1.22.0")
+
+    // Set up Spinnaker versions server.
+    val halconfigServer = HttpServer.create(InetSocketAddress(0), 0).apply {
+      createContext("/versions.yml") {
+        it.responseHeaders.set("Content-Type", "application/x-yaml")
+        it.sendResponseHeaders(200, 0)
+        it.responseBody.write("""
+          latestSpinnaker: "1.22.1"
+          versions:
+            - version: 1.22.1
+            - version: 1.21.4
+            - version: 1.20.7
+          """.trimIndent().toByteArray())
+        it.responseBody.close()
+      }
+      start()
+    }
+
+    val (_, subproject) = withProjects {
+      rootProject {
+        plugins.apply("io.spinnaker.plugin.bundler")
+        spinnakerBundle {
+          compatibility {
+            spinnaker = compatibility
+            halconfigBaseURL = "http://localhost:${halconfigServer.address.port}"
+          }
+        }
+      }
+      subproject("$service-plugin") {
+        plugins.apply("io.spinnaker.plugin.compatibility-test-runner")
+        plugins.apply("io.spinnaker.plugin.service-extension")
+        spinnakerPlugin {
+          serviceName = service
+        }
+      }
+    }
+
+    listOf(
+      "1.22.1", // "latest", but also included in "supported"
+      "1.22.0", // explicit
+      "1.21.4", // included in "supported"
+      "1.20.7", // included in "supported"
+      "master-latest-validated" // "nightly"
+    ).forEach {
+      assertNotNull(subproject.tasks.findByName("${SpinnakerCompatibilityTestRunnerPlugin.TASK_NAME}-$service-plugin-$it"))
+    }
+  }
+}
+
+private fun Project.evaluate() = withGroovyBuilder { "evaluate"() }
+
+private fun withProjects(dsl: ProjectsDsl.() -> Unit): Pair<Project, Project> {
+  val rootProject = ProjectBuilder.builder().build()
+  val subprojectBuilder = ProjectBuilder.builder().withParent(rootProject)
+  var subproject: Project? = null
+
+  object : ProjectsDsl {
+    override fun rootProject(dsl: Project.() -> Unit) {
+      rootProject.dsl()
+    }
+    override fun subproject(name: String, dsl: Project.() -> Unit) {
+      subproject = subprojectBuilder.withName(name).build().also { it.dsl() }
+    }
+  }.dsl()
+
+  return if (subproject != null) Pair(rootProject, subproject!!) else throw IllegalStateException("Must configure subproject!")
+}
+
+private interface ProjectsDsl {
+  fun rootProject(dsl: Project.() -> Unit)
+  fun subproject(name: String, dsl: Project.() -> Unit)
+}
+
+private fun Project.spinnakerBundle(dsl: SpinnakerBundleExtension.() -> Unit) =
+  extensions.getByType(SpinnakerBundleExtension::class.java).dsl()
+
+private fun Project.spinnakerPlugin(dsl: SpinnakerPluginExtension.() -> Unit) =
+  extensions.getByType(SpinnakerPluginExtension::class.java).dsl()
+


### PR DESCRIPTION
Provides three aliases: `latest`, `nightly`, and `supported`.