### PR TITLE
feat(compatibility): allow optional tests

### DIFF
--- a/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginFunctionalTest.kt
+++ b/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerExtensionGradlePluginFunctionalTest.kt
@@ -22,6 +22,8 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
+const val TEST_ROOT = "build/functionaltest"
+
 /**
  * Functional test for the 'com.netflix.spinnaker.gradle.extension' plugin.
  */
@@ -29,7 +31,7 @@ class SpinnakerExtensionGradlePluginFunctionalTest {
 
   @BeforeTest
   fun cleanup() {
-    File("build/functionaltest").also {
+    File(TEST_ROOT).also {
       if (it.exists()) it.deleteRecursively()
     }
   }
@@ -37,7 +39,7 @@ class SpinnakerExtensionGradlePluginFunctionalTest {
   @Test
   fun `can run task`() {
     // Setup the test build
-    val projectDir = File("build/functionaltest")
+    val projectDir = File(TEST_ROOT)
     projectDir.mkdirs()
     projectDir.resolve("settings.gradle").writeText("")
     projectDir.resolve("build.gradle").writeText("""
@@ -60,127 +62,23 @@ class SpinnakerExtensionGradlePluginFunctionalTest {
 
   @Test
   fun `can run an end-to-end build, including compatibility test`() {
-    val service = "orca"
-    val version = "1.22.0"
-    val root = "build/functionaltest"
-    val pluginPackage = "io.armory.plugin"
+    TestPlugin.Builder()
+      .withRootDir(TEST_ROOT)
+      .withService("orca")
+      .withCompatibilityTestVersion("1.22.0")
+      .build()
 
-    directory(root) {
-      write("settings.gradle") {
-        """
-          pluginManagement {
-            repositories {
-              gradlePluginPortal()
-            }
-          }
-
-          include "$service-plugin"
-        """
-      }
-      write("build.gradle") {
-        """
-          plugins {
-            id("io.spinnaker.plugin.bundler")
-          }
-
-          spinnakerBundle {
-            pluginId = "Armory.TestPlugin"
-            version = "0.0.1"
-            description = "A plugin used to demonstrate that the build works end-to-end"
-            provider = "daniel.peach@armory.io"
-            compatibility {
-              spinnaker = ["$version"]
-            }
-          }
-        """
-      }
-
-      subdirectory("$service-plugin") {
-        write("build.gradle") {
-          """
-            plugins {
-              id("org.jetbrains.kotlin.jvm")
-            }
-
-            apply plugin: "io.spinnaker.plugin.service-extension"
-            apply plugin: "io.spinnaker.plugin.compatibility-test-runner"
-
-            repositories {
-              mavenCentral()
-              jcenter()
-              maven { url "https://spinnaker-releases.bintray.com/jars" }
-            }
-
-            spinnakerPlugin {
-              serviceName = "$service"
-              requires = "$service>=0.0.0"
-              pluginClass = "$pluginPackage.MyPlugin"
-            }
-
-            dependencies {
-              compileOnly("org.pf4j:pf4j:3.2.0")
-
-              testImplementation("org.jetbrains.kotlin:kotlin-test")
-              testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-              testImplementation("org.jetbrains.kotlin:kotlin-test")
-              testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
-            }
-          """
-        }
-
-        subdirectory("src/test/kotlin/${pluginPackage.replace(".", "/")}") {
-          // A real test would test something about a plugin here...
-          write("MyTest.kt") {
-            """
-              package $pluginPackage
-
-              import kotlin.test.Test
-              import kotlin.test.assertTrue
-
-              class MyTest {
-                @Test
-                fun addition() {
-                  assertTrue(1 + 1 == 2)
-                }
-              }
-            """
-          }
-        }
-
-        subdirectory("src/main/java/${pluginPackage.replace(".", "/")}") {
-          write("MyPlugin.java") {
-            """
-              package $pluginPackage;
-
-              import org.pf4j.Plugin;
-              import org.pf4j.PluginWrapper;
-
-              public class MyPlugin extends Plugin {
-
-                public MyPlugin(PluginWrapper wrapper) {
-                  super(wrapper);
-                }
-              }
-            """
-          }
-        }
-      }
-    }
-
-    val result = GradleRunner
+    val build = GradleRunner
       .create()
       .forwardOutput()
       .withPluginClasspath()
       .withArguments("compatibilityTest", "releaseBundle")
-      .withProjectDir(File(root))
+      .withProjectDir(File(TEST_ROOT))
       .build()
 
-    assertTrue(result.output.contains("BUILD SUCCESSFUL"))
-
-    val distributions = File(root).resolve("build/distributions")
-
+    assertTrue(build.output.contains("BUILD SUCCESSFUL"))
+    val distributions = File(TEST_ROOT).resolve("build/distributions")
     assertTrue(distributions.resolve("functionaltest.zip").exists())
-
     val pluginInfo = distributions.resolve("plugin-info.json").readText()
     listOf(
       """
@@ -200,24 +98,102 @@ class SpinnakerExtensionGradlePluginFunctionalTest {
       assertTrue(pluginInfo.contains(it))
     }
   }
-}
 
-private fun directory(path: String, dsl: DirectoryDsl.() -> Unit) {
-  val dir = File(path)
-  dir.mkdirs()
+  @Test
+  fun `compatibility test task fails with failing test`() {
+    TestPlugin.Builder()
+      .withRootDir(TEST_ROOT)
+      .withService("orca")
+      .withCompatibilityTestVersion("1.22.0")
+      .withTest("MyFailingTest.kt", """
+        package {{ package }}
 
-  object : DirectoryDsl {
-    override fun subdirectory(path: String, dsl: DirectoryDsl.() -> Unit) {
-      directory(dir.resolve(path).toString(), dsl)
+        import kotlin.test.Test
+        import kotlin.test.assertTrue
+
+        class MyTest {
+          @Test
+          fun badAddition() {
+            assertTrue(1 + 1 == 3)
+          }
+        }
+      """)
+      .build()
+
+    val build = GradleRunner
+      .create()
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments("compatibilityTest", "releaseBundle")
+      .withProjectDir(File(TEST_ROOT))
+      .buildAndFail()
+
+    assertTrue(build.output.contains("Compatibility tests failed for Spinnaker 1.22.0"))
+  }
+
+  @Test
+  fun `compatibility test task succeeds if failing test is not required`() {
+    TestPlugin.Builder()
+      .withService("orca")
+      .withCompatibilityTestVersion("1.22.0")
+      .withRootBuildGradle("""
+        plugins {
+          id("io.spinnaker.plugin.bundler")
+        }
+
+        spinnakerBundle {
+          pluginId = "Armory.TestPlugin"
+          version = "0.0.1"
+          description = "A plugin used to demonstrate that the build works end-to-end"
+          provider = "daniel.peach@armory.io"
+          compatibility {
+            spinnaker {
+              test(version: "{{ version }}", required: false)
+            }
+          }
+        }
+      """)
+      .withTest("MyFailingTest.kt", """
+        package {{ package }}
+
+        import kotlin.test.Test
+        import kotlin.test.assertTrue
+
+        class MyTest {
+          @Test
+          fun badAddition() {
+            assertTrue(1 + 1 == 3)
+          }
+        }
+      """)
+      .build()
+
+    val build = GradleRunner
+      .create()
+      .forwardOutput()
+      .withPluginClasspath()
+      .withArguments("compatibilityTest", "releaseBundle")
+      .withProjectDir(File(TEST_ROOT))
+      .build()
+
+    assertTrue(build.output.contains("BUILD SUCCESSFUL"))
+    val pluginInfo = File(TEST_ROOT).resolve("build/distributions/plugin-info.json").readText()
+    listOf(
+      """
+        "id": "Armory.TestPlugin",
+      """.trimIndent(),
+      """
+            "compatibility": [
+                {
+                    "service": "orca",
+                    "result": "FAILURE",
+                    "platformVersion": "1.22.0",
+                    "serviceVersion": "2.16.0-20200817170018"
+                }
+            ]
+      """
+    ).forEach {
+      assertTrue(pluginInfo.contains(it))
     }
-
-    override fun write(file: String, contents: () -> String) {
-      dir.resolve(file).writeText(contents().trimIndent())
-    }
-  }.dsl()
-}
-
-private interface DirectoryDsl {
-  fun subdirectory(path: String, dsl: DirectoryDsl.() -> Unit)
-  fun write(file: String, contents: () -> String)
+  }
 }

--- a/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/fixture.kt
+++ b/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/fixture.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.extension
+
+import java.io.File
+
+internal class TestPlugin {
+  var pluginPackage = "io.armory.plugins"
+  var service = "orca"
+  var rootDir = TEST_ROOT
+  var compatibilityTestVersion = "1.22.0"
+
+  var settingsGradle = """
+    pluginManagement {
+      repositories {
+        gradlePluginPortal()
+      }
+    }
+
+    include "{{ service }}-plugin"
+  """
+
+  var rootBuildGradle = """
+    plugins {
+      id("io.spinnaker.plugin.bundler")
+    }
+
+    spinnakerBundle {
+      pluginId = "Armory.TestPlugin"
+      version = "0.0.1"
+      description = "A plugin used to demonstrate that the build works end-to-end"
+      provider = "daniel.peach@armory.io"
+      compatibility {
+        spinnaker {
+          test "{{ version }}"
+        }
+      }
+    }
+  """
+
+  var subprojectBuildGradle = """
+    plugins {
+      id("org.jetbrains.kotlin.jvm")
+    }
+
+    apply plugin: "io.spinnaker.plugin.service-extension"
+    apply plugin: "io.spinnaker.plugin.compatibility-test-runner"
+
+    repositories {
+      mavenCentral()
+      jcenter()
+      maven { url "https://spinnaker-releases.bintray.com/jars" }
+    }
+
+    spinnakerPlugin {
+      serviceName = "{{ service }}"
+      requires = "{{ service }}>=0.0.0"
+      pluginClass = "{{ package }}.MyPlugin"
+    }
+
+    dependencies {
+      compileOnly("org.pf4j:pf4j:3.2.0")
+
+      testImplementation("org.jetbrains.kotlin:kotlin-test")
+      testImplementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+      testImplementation("org.jetbrains.kotlin:kotlin-test")
+      testImplementation("org.jetbrains.kotlin:kotlin-test-junit")
+    }
+  """
+
+  var pluginName = "MyPlugin.java"
+  var plugin = """
+    package {{ package }};
+
+    import org.pf4j.Plugin;
+    import org.pf4j.PluginWrapper;
+
+    public class MyPlugin extends Plugin {
+
+      public MyPlugin(PluginWrapper wrapper) {
+        super(wrapper);
+      }
+    }
+  """
+
+  var testName = "MyTest.kt"
+  var test = """
+    package {{ package }}
+
+    import kotlin.test.Test
+    import kotlin.test.assertTrue
+
+    class MyTest {
+      @Test
+      fun addition() {
+        assertTrue(1 + 1 == 2)
+      }
+    }
+  """
+
+  class Builder {
+    private val fixture = TestPlugin()
+
+    fun withPackage(pluginPackage: String): Builder {
+      fixture.apply { this.pluginPackage = pluginPackage }
+      return this
+    }
+
+    fun withService(service: String): Builder {
+      fixture.apply { this.service = service }
+      return this
+    }
+
+    fun withRootDir(rootDir: String): Builder {
+      fixture.apply { this.rootDir = rootDir }
+      return this
+    }
+
+    fun withCompatibilityTestVersion(version: String): Builder {
+      fixture.apply { compatibilityTestVersion = version }
+      return this
+    }
+
+    fun withSettingsGradle(settingsGradle: String): Builder {
+      fixture.apply { this.settingsGradle = settingsGradle }
+      return this
+    }
+
+    fun withRootBuildGradle(rootBuildGradle: String): Builder {
+      fixture.apply { this.rootBuildGradle = rootBuildGradle }
+      return this
+    }
+
+    fun withSubprojectBuildGradle(subprojectBuildGradle: String): Builder {
+      fixture.apply { this.subprojectBuildGradle = subprojectBuildGradle }
+      return this
+    }
+
+    fun withPlugin(name: String, plugin: String): Builder {
+      fixture.apply { pluginName = name; this.plugin = plugin }
+      return this
+    }
+
+    fun withTest(name: String, test: String): Builder {
+      fixture.apply { testName = name; this.test = test }
+      return this
+    }
+
+    fun build(): TestPlugin {
+      with(fixture) {
+        directory(rootDir) {
+          write("settings.gradle") {
+            settingsGradle.interpolate()
+          }
+          write("build.gradle") {
+            rootBuildGradle.interpolate()
+          }
+          subdirectory("$service-plugin") {
+            write("build.gradle") {
+              subprojectBuildGradle.interpolate()
+            }
+            subdirectory("src/main/java/${pluginPackage.replace(".", "/")}") {
+              write(pluginName) {
+                plugin.interpolate()
+              }
+            }
+            subdirectory("src/test/kotlin/${pluginPackage.replace(".", "/")}") {
+              write(testName) {
+                test.interpolate()
+              }
+            }
+          }
+        }
+      }
+      return fixture
+    }
+
+    private fun String.interpolate(): String {
+      var result = this
+      listOf(
+        "package" to fixture.pluginPackage,
+        "service" to fixture.service,
+        "version" to fixture.compatibilityTestVersion
+      ).forEach { (k, v) ->
+        result = result.replace("{{ $k }}", v)
+      }
+      return result
+    }
+  }
+}
+
+internal fun directory(path: String, dsl: DirectoryDsl.() -> Unit) {
+  val dir = File(path)
+  dir.mkdirs()
+
+  object : DirectoryDsl {
+    override fun subdirectory(path: String, dsl: DirectoryDsl.() -> Unit) {
+      directory(dir.resolve(path).toString(), dsl)
+    }
+
+    override fun write(file: String, contents: () -> String) {
+      dir.resolve(file).writeText(contents().trimIndent())
+    }
+  }.dsl()
+}
+
+internal interface DirectoryDsl {
+  fun subdirectory(path: String, dsl: DirectoryDsl.() -> Unit)
+  fun write(file: String, contents: () -> String)
+}

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerBundleExtension.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerBundleExtension.kt
@@ -86,38 +86,19 @@ open class SpinnakerBundleExtension {
    * An extension block that describes a plugin's compatibility.
    */
   val compatibility
-    get() = (this as ExtensionAware).extensions.getByName(SpinnakerCompatibilityExtension.NAME) as SpinnakerCompatibilityExtension
+    get() = withExtensions { getByName(SpinnakerCompatibilityExtension.NAME) as SpinnakerCompatibilityExtension }
 
   // For Kotlin build scripts.
   fun compatibility(configure: SpinnakerCompatibilityExtension.() -> Unit) =
-    (this as ExtensionAware).also {
-      it.extensions.create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
-      it.extensions.configure(SpinnakerCompatibilityExtension.NAME, configure)
+    withExtensions {
+      create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
+      configure(SpinnakerCompatibilityExtension.NAME, configure)
     }
 
   // For Groovy build scripts.
   fun compatibility(configure: Action<SpinnakerCompatibilityExtension>) =
-    (this as ExtensionAware).also {
-      it.extensions.create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
-      it.extensions.configure(SpinnakerCompatibilityExtension.NAME, configure)
+    withExtensions {
+      create<SpinnakerCompatibilityExtension>(SpinnakerCompatibilityExtension.NAME)
+      configure(SpinnakerCompatibilityExtension.NAME, configure)
     }
-
-  open class SpinnakerCompatibilityExtension {
-    /**
-     * A list of top-level Spinnaker versions (e.g., 1.21.0, 1.22.0) that this plugin is compatible with.
-     */
-    var spinnaker: List<String>
-      set(value) {
-        _spinnaker = value
-      }
-      get() = _spinnaker ?: throw IllegalStateException("spinnakerBundle.compatibility.spinnaker must not be null")
-
-    private var _spinnaker: List<String>? = null
-
-    var halconfigBaseURL: String = "https://storage.googleapis.com/halconfig"
-
-    companion object {
-      const val NAME = "compatibility"
-    }
-  }
 }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerCompatibilityExtension.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/SpinnakerCompatibilityExtension.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.extension.extensions
+
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.gradle.extension.PluginObjectMapper
+import com.netflix.spinnaker.gradle.extension.compatibility.SpinnakerVersionAlias
+import org.gradle.api.Action
+import org.gradle.kotlin.dsl.create
+
+/**
+ * Configuration for plugin compatibility tests.
+ * */
+open class SpinnakerCompatibilityExtension {
+  /**
+   * A list of top-level Spinnaker versions (e.g., 1.21.0, 1.22.0) that this plugin should be tested against.
+   *
+   * e.g.,
+   * spinnakerBundle {
+   *   compatibility {
+   *     spinnaker = ["1.21.0", "1.22.0"]
+   *   }
+   * }
+   */
+  var spinnaker: List<String> = emptyList()
+
+  /**
+   * The following "spinnaker" methods provide a DSL for more complex test configuration options.
+   * Currently you can only define if a test is "required" or not for a given Spinnaker version; i.e.,
+   * should the top-level compatibilityTest task fail should if a test fails?
+   * */
+
+  /**
+   * For Kotlin build scripts.
+   * e.g.,
+   * spinnakerBundle {
+   *   compatibility {
+   *     spinnaker {
+   *       test("1.21.1", required = false)
+   *       test("1.22.0")
+   *     }
+   *   }
+   * }
+   * */
+  fun spinnaker(configure: VersionTestConfigExtension.() -> Unit) {
+    withExtensions {
+      create<VersionTestConfigExtension>(VersionTestConfigExtension.NAME)
+      configure(VersionTestConfigExtension.NAME, configure)
+    }
+  }
+
+  /**
+   * For Groovy build scripts.
+   * e.g.,
+   * spinnakerBundle {
+   *   compatibility {
+   *     spinnaker {
+   *       test(version: "1.21.1", required: false)
+   *       test "1.22.0"
+   *     }
+   *   }
+   * }
+   * */
+  fun spinnaker(configure: Action<VersionTestConfigExtension>) {
+    withExtensions {
+      create<VersionTestConfigExtension>(VersionTestConfigExtension.NAME)
+      configure(VersionTestConfigExtension.NAME, configure)
+    }
+  }
+
+  internal val versionTestConfigs
+    get() = withExtensions {
+      val extension = findByName(VersionTestConfigExtension.NAME) as? VersionTestConfigExtension
+      spinnaker.map { VersionTestConfig(it) } + (extension?.configs ?: emptyList())
+    }
+
+  var halconfigBaseURL: String = "https://storage.googleapis.com/halconfig"
+
+  companion object {
+    const val NAME = "compatibility"
+  }
+}
+
+open class VersionTestConfigExtension {
+
+  internal var configs = emptyList<VersionTestConfig>()
+
+  // For Kotlin DSLs:
+  // test("1.21.1", required = true)
+  fun test(version: String, required: Boolean = true) {
+    configs = configs + VersionTestConfig(version, required)
+  }
+
+  // For Groovy DSLs (Groovy can't handle default parameters):
+  // test "1.21.1"
+  fun test(version: String) {
+    configs = configs + VersionTestConfig(version)
+  }
+
+  // For Groovy DSLs:
+  // test(version: "1.21.1", required: false)
+  fun test(config: Map<String, Any>) {
+    configs = configs + PluginObjectMapper.mapper.convertValue<VersionTestConfig>(config)
+  }
+
+  companion object {
+    const val NAME = "spinnaker"
+  }
+}
+
+data class VersionTestConfig(val version: String, val required: Boolean = true) {
+  val alias: SpinnakerVersionAlias? = if (SpinnakerVersionAlias.isAlias(version)) SpinnakerVersionAlias.from(version) else null
+}

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/dsl.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/extensions/dsl.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.gradle.extension.extensions
+
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.plugins.ExtensionContainer
+
+internal fun <T> Any.withExtensions(cb: ExtensionContainer.() -> T) = (this as ExtensionAware).extensions.let(cb)


### PR DESCRIPTION
The goal here is to allow plugin developers to run tests against Spinnaker versions that their plugin may or may not be compatible with.