### PR TITLE
fix(*): Support for parsing boolean project properties

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayPublishExtension.groovy
@@ -197,6 +197,9 @@ class BintrayPublishExtension {
 
   protected <T> T projectProperty(Class<T> type, String projectPropertyName, T defaultValue) {
     if (project.hasProperty(projectPropertyName)) {
+      if (type == Boolean) {
+        return Boolean.valueOf(project.property(projectPropertyName).toString()) as T
+      }
       return project.property(projectPropertyName).asType(type)
     }
     return defaultValue


### PR DESCRIPTION
Prior to this fix, any intended boolean project property (ie. `-PbintrayPublishDebEnabled`) would
be interpreted as `true` apparently due to how `asType()` works.