### PR TITLE
fix(builds): Log a warning rather than fail the build, if the version has already been created and continue

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayCreateVersionTask.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/bintray/BintrayCreateVersionTask.groovy
@@ -31,6 +31,10 @@ class BintrayCreateVersionTask extends DefaultTask {
     def response = http.response
     project.logger.info("Create Version request finished with status $response.responseCode: $response.statusLine")
     project.logger.info("Create Version response:\n$response.responseBody")
+    if (response.statusLine == '409') {
+      project.logger.warn("Bintray rejected the new version because it already exists, continuing...")
+      return
+    }
     response.throwIfFailed("create version $project.version")
   }
 }


### PR DESCRIPTION
The build and validate jobs for the various releases and release patches seem to fail frequently

![image](https://user-images.githubusercontent.com/711726/106181054-f83e2680-6151-11eb-831b-90cac141ff3e.png)

When you dig in

![image](https://user-images.githubusercontent.com/711726/106181095-02602500-6152-11eb-97e5-4968ea807436.png)

The failure is a result of the job trying to create a version that already exists

![image](https://user-images.githubusercontent.com/711726/106181179-202d8a00-6152-11eb-91c3-b2487abd3a8e.png)

I tracked this down to 

https://github.com/spinnaker/buildtool/blob/master/dev/buildtool/cloudbuild/debs.yml#L31

and potentially

https://github.com/spinnaker/buildtool/blob/8d23e6ccef4fb4dacbc1905853a1705cd46cbb8a/dev/buildtool/gradle_support.py#L356

Re-using the same build number between jobs.

This PR makes the gradle plugin warn and not fail if there is a conflict, in hopes that the builds will be more stable.