### PR TITLE
feat(conventions): include maven central as a default repository

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -22,6 +22,7 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
       project.plugins.withType(JavaBasePlugin) {
         project.plugins.apply(MavenPublishPlugin)
         project.repositories.jcenter()
+        project.repositories.mavenCentral()
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)
         convention.sourceCompatibility = JavaVersion.VERSION_11
         convention.targetCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
I think it makes sense to sort maven central below jcenter for now so that ideally that only thing we're pulling from maven is the new `io.spinnaker` coordinates.