### PR TITLE
chore(build): remove jcenter since it always responds with 403

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -21,7 +21,6 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
     void apply(Project project) {
       project.plugins.withType(JavaBasePlugin) {
         project.plugins.apply(MavenPublishPlugin)
-        project.repositories.jcenter()
         project.repositories.mavenCentral()
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)
         convention.sourceCompatibility = JavaVersion.VERSION_11


### PR DESCRIPTION
and slows builds way down.

Note that there are more references to jcenter here. This is an attempt to fix publishing of jars to nexus, or at least reduce log noise when doing that...so that we can eventually remove the remaining references and actually have tests pass.