### PR TITLE
fix(build): update to use dependsOn over mustRunAfter

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
@@ -58,7 +58,7 @@ class SpinnakerUIExtensionPlugin : Plugin<Project> {
     project.afterEvaluate {
       project.tasks.getByName("build") {
         dependsOn("yarn", "yarnBuild", "yarnModules")
-        tasks.findByName("yarnBuild")?.mustRunAfter("yarnModules")
+        tasks.findByName("yarnBuild")?.dependsOn("yarnModules")
       }
     }
   }

--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
@@ -53,12 +53,12 @@ class SpinnakerUIExtensionPlugin : Plugin<Project> {
       group = Plugins.GROUP
       workingDir = project.projectDir
       commandLine = listOf("yarn", "build")
+      dependsOn("yarnModules")
     }
 
     project.afterEvaluate {
       project.tasks.getByName("build") {
-        dependsOn("yarn", "yarnBuild", "yarnModules")
-        tasks.findByName("yarnBuild")?.dependsOn("yarnModules")
+        dependsOn("yarn", "yarnBuild")
       }
     }
   }


### PR DESCRIPTION
Running `yarnBuild` should also run `yarnModules`