### PR TITLE
fix(compatibility): modify groupId to io.spinnaker in CompatibilityTestRunner

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/compatibility/SpinnakerCompatibilityTestRunnerPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/compatibility/SpinnakerCompatibilityTestRunnerPlugin.kt
@@ -85,7 +85,7 @@ class SpinnakerCompatibilityTestRunnerPlugin : Plugin<Project> {
           it.services[plugin.serviceName]?.version ?: throw IllegalStateException("Could not find version for service ${plugin.serviceName}")
         }
 
-        project.dependencies.platform("com.netflix.spinnaker.${plugin.serviceName}:${plugin.serviceName}-bom:$resolvedServiceVersion").apply {
+        project.dependencies.platform("io.spinnaker.${plugin.serviceName}:${plugin.serviceName}-bom:$resolvedServiceVersion").apply {
           force = true
         }.also {
           project.dependencies.add(runtimeConfiguration, it)

--- a/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPluginTest.kt
+++ b/spinnaker-extensions/src/test/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerCompatibilityTestRunnerPluginTest.kt
@@ -163,7 +163,7 @@ class SpinnakerCompatibilityTestRunnerPluginTest {
       assertNotNull(runtime)
 
       val bom = runtime.dependencies.find { dependency ->
-        dependency.group == "com.netflix.spinnaker.${service}" && dependency.name == "$service-bom"
+        dependency.group == "io.spinnaker.${service}" && dependency.name == "$service-bom"
       }
       assertNotNull(bom)
       assertEquals("google-service-version-${version}", bom.version)


### PR DESCRIPTION
Starting Spinnaker 1.26.x, the groupId is switched from `com.netflix.spinnaker` to `io.spinnaker` in Spinnaker different components (for example [orca](https://github.com/spinnaker/orca/commit/b5107c9bf200ebcda6eef96691021dd2b33bdce1#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L28), [clouddriver](https://github.com/spinnaker/clouddriver/commit/2d8a2d0803d03e2feaa6c2aaff312d2c6943e800#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L47), [gate](https://github.com/spinnaker/gate/commit/bf9d7c80060572be1aa03887f7842e08c05f501e#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L11) ...etc.). This PR to modify `CompatibilityTestRunnerPlugin` to make it use the updated dependency group so it works correctly with Spinnaker 1.26.x