### PR TITLE
fix(publishing/artifactory): support parsing boolean project properties

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
@@ -111,6 +111,9 @@ class ArtifactRegistryPublishExtension {
 
   protected <T> T projectProperty(Class<T> type, String projectPropertyName, T defaultValue) {
     if (project.hasProperty(projectPropertyName)) {
+      if (type == Boolean) {
+        return Boolean.valueOf(project.property(projectPropertyName).toString()) as T
+      }
       return project.property(projectPropertyName).asType(type)
     }
     return defaultValue


### PR DESCRIPTION
Without this, boolean properties are interpreted as true even when specified as false.

Similar to https://github.com/spinnaker/spinnaker-gradle-project/pull/158