### PR TITLE
chore(publishing): disable publishing of maven artifacts via the arti…

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
@@ -30,7 +30,7 @@ class ArtifactRegistryPublishExtension {
     this.project = project
     ObjectFactory props = project.objects
     enabled = props.property(Boolean).convention(false)
-    mavenEnabled = props.property(Boolean).convention(true)
+    mavenEnabled = props.property(Boolean).convention(false)
     aptEnabled = props.property(Boolean).convention(true)
     mavenProject = props.property(String).convention("spinnaker-community")
     mavenLocation = props.property(String).convention("us")


### PR DESCRIPTION
…fact registry plugin

1. It doesn't work

2. We're publishing jars to nexus and that seems sufficient.