### PR TITLE
chore(plugins): re-enable spinnaker-extensions compatibility tests

### DIFF
--- a/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/fixture.kt
+++ b/spinnaker-extensions/src/functionaltest/kotlin/com/netflix/spinnaker/gradle/extension/fixture.kt
@@ -62,8 +62,6 @@ internal class TestPlugin {
 
     repositories {
       mavenCentral()
-      jcenter()
-      maven { url "https://spinnaker-releases.bintray.com/jars" }
     }
 
     spinnakerPlugin {


### PR DESCRIPTION
now that a version of spinnaker has been released (1.27.0) that has artifacts published in
a live artifact repo (maven central).

This effectively reverts https://github.com/spinnaker/spinnaker-gradle-project/pull/167.