### PR TITLE
fix(plugin): Issue with non-existing file/folder location used in Spring properties while upgrading spring boot 2.4.x.

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
@@ -22,7 +22,7 @@ class SpinnakerApplicationPlugin implements Plugin<Project> {
         appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom"
 
         project.tasks.withType(CreateStartScripts) {
-            it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.additional-location=/opt/spinnaker/config/"]
+            it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.import=optional:/opt/spinnaker/config/"]
             it.doLast {
                 unixScript.text = unixScript.text.replace('DEFAULT_JVM_OPTS=', '''\
                     if [ -f /etc/default/spinnaker ]; then


### PR DESCRIPTION
With spring boot 2.4, spring location properties will no longer fail silently if the file or folder does not exist. Now, requires prefix "optional:" for the location.

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#config-file-processing-application-properties-and-yaml-files

And introducing new spring additional data importing property suggested below, to be used with Spring boot 2.4: 

https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-Config-Data-Migration-Guide 

https://docs.spring.io/spring-boot/docs/2.4.0/reference/html/spring-boot-features.html#boot-features-external-config-files-importing