### PR TITLE
chore(publishing): upgrade artifact registry jar

### DIFF
--- a/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-project-plugin/build.gradle
@@ -5,9 +5,11 @@ dependencies {
   implementation 'org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r'
   implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'
   implementation 'gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.1'
-  implementation 'com.google.cloud:google-cloud-storage:1.113.1'
-  implementation 'com.google.apis:google-api-services-artifactregistry:v1beta2-rev20220203-1.32.1'
-  implementation 'com.google.api-client:google-api-client:1.30.10'
+  implementation platform('com.google.cloud:libraries-bom:26.1.4')
+
+  implementation 'com.google.cloud:google-cloud-storage'
+  implementation 'com.google.apis:google-api-services-artifactregistry:v1beta2-rev20221022-2.0.0'
+  implementation 'com.google.api-client:google-api-client:2.0.0'
   implementation 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
   implementation 'io.github.gradle-nexus:publish-plugin:1.1.0'
 }

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryDebPublishTask.java
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryDebPublishTask.java
@@ -174,7 +174,7 @@ class ArtifactRegistryDebPublishTask extends DefaultTask {
 
     Stopwatch timer = Stopwatch.createStarted();
     while (!operationIsDone(operation) && !operationTimedOut(timer)) {
-      Thread.sleep(1000);
+      Thread.sleep(30000);
       operation = artifactRegistryClient.projects().locations().operations().get(operation.getName()).execute();
     }
 

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/publishing/artifactregistry/ArtifactRegistryPublishExtension.groovy
@@ -39,7 +39,7 @@ class ArtifactRegistryPublishExtension {
     aptLocation = props.property(String).convention("us")
     aptRepository = props.property(String).convention("apt")
     aptTempGcsBucket = props.property(String).convention("spinnaker-deb-temp-uploads")
-    aptImportTimeoutSeconds = props.property(Integer).convention(60)
+    aptImportTimeoutSeconds = props.property(Integer).convention(3600)
   }
 
   Provider<Boolean> enabled() {


### PR DESCRIPTION
Also widened the default timeout for polling for imports based on recent builds timing out. There is some intertwining of dependencies between what the GCS lib and the artifact registry are using so I had to upgrade both.