### PR TITLE
refactor(build): stop applying groovy plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ subprojects {
   }
 
   apply plugin: 'com.diffplug.spotless'
-  apply plugin: 'groovy'
   apply plugin: 'idea'
   apply plugin: 'java-gradle-plugin'
   apply plugin: 'com.gradle.plugin-publish'

--- a/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-project-plugin/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'groovy'
+
 dependencies {
   implementation 'com.github.jk1:gradle-license-report:1.8'
   implementation 'org.owasp:dependency-check-gradle:5.1.0'


### PR DESCRIPTION
since there's no groovy code to compile.

As well, this means no more groovydoc generation, which, with any luck, will mean we no longer get errors like
```
Execution failed for task ':spinnaker-extensions:publishPlugins'.
> Failed to post to server.
  Server responded with:
  Invalid publication, you have different artifacts with the same hash: (JAVADOC and GROOVYDOC). Support for this is only available with version 1.0+ of the plugin-publish plugin.
```
from https://github.com/spinnaker/spinnaker-gradle-project/actions/runs/3753925474/jobs/6377662818

Attempts to upgrade the plugin-publish plugin to 1.0+ weren't straightforward, so here we are.