### PR TITLE
chore(deps): Upgrade org.gradle.crypto.checksum.gradle.plugin to support Gradle 8

### DIFF
--- a/spinnaker-extensions/build.gradle.kts
+++ b/spinnaker-extensions/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 }
 
 dependencies {
-  implementation("org.gradle.crypto.checksum:org.gradle.crypto.checksum.gradle.plugin:1.2.0")
+  implementation("org.gradle.crypto.checksum:org.gradle.crypto.checksum.gradle.plugin:1.4.0")
 
   implementation(platform("com.fasterxml.jackson:jackson-bom:2.11.1"))
   implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")


### PR DESCRIPTION
Hi folks!

I found that current used checksum gradle plugin version fails in modern Gradle versions with the following:

```
Cannot use @TaskAction annotation on method Checksum.generateChecksumFiles() because interface org.gradle.api.tasks.incremental.IncrementalTaskInputs is not a valid parameter to an action method.
```

`IncrementalTaskInputs` are removed. However, I found that the plugin author already has 1.4.0 which includes https://github.com/gradle/gradle-checksum/commit/54d922bb2d1fb70fcf3a4bff64abb267476930b3 that solves the problem