### PR TITLE
refactor(deprecation): remove deprecated gradle constructs/features to be consumed by other spinnaker components

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/project/SpinnakerProjectPlugin.groovy
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.gradle.publishing.PublishingPlugin
 import com.netflix.spinnaker.gradle.publishing.nexus.NexusPublishPlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.DuplicatesStrategy
+import org.gradle.api.tasks.AbstractCopyTask
 
 class SpinnakerProjectPlugin implements Plugin<Project> {
 
@@ -31,5 +33,8 @@ class SpinnakerProjectPlugin implements Plugin<Project> {
     project.plugins.apply(PublishingPlugin)
     project.plugins.apply(ArtifactRegistryPublishPlugin)
     project.plugins.apply(NexusPublishPlugin)
+    project.tasks.withType(AbstractCopyTask) {
+       it.configure {setProperty("duplicatesStrategy",DuplicatesStrategy.EXCLUDE)}
+    }
   }
 }


### PR DESCRIPTION
While executing the build script with --warning-mode=fail for fiat, gate, clouddriver, orca, front50, igor, echo and halyard received below error:
```
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```
And the common deprecated gradle feature is:
```
Copying or archiving duplicate paths with the default duplicates strategy has been deprecated. This is scheduled to be removed in Gradle 7.0. Explicitly set the duplicates strategy to 'DuplicatesStrategy.INCLUDE' if we want to allow duplicate paths. Consult the upgrading guide for further information: https://docs.gradle.org/6.8.3/userguide/upgrading_version_5.html#implicit_duplicate_strategy_for_copy_or_archive_tasks_has_been_deprecated
```
The issue is raised by `processResources` and `sourceJar` tasks and both inherit from `AbstractCopyTask`. So updated the tasks of type `AbstractCopyTask` with `duplicatesStrategy` property explicitly in `spinnaker-project-plugin`, that makes the property consumable by all spinnaker components.