### PR TITLE
chore(dependencies): upgrade com.diffplug.spotless:spotless-plugin-gradle and associated dependencies of google-java-format and ktlint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.diffplug.spotless" version "5.1.0" apply false
+  id "com.diffplug.spotless" version "5.17.1" apply false
   id "com.gradle.plugin-publish" version "0.12.0" apply false
 }
 

--- a/spinnaker-project-plugin/build.gradle
+++ b/spinnaker-project-plugin/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'groovy'
 dependencies {
   implementation 'com.github.jk1:gradle-license-report:1.8'
   implementation 'org.owasp:dependency-check-gradle:5.1.0'
-  implementation "com.diffplug.spotless:spotless-plugin-gradle:5.1.0"
+  implementation "com.diffplug.spotless:spotless-plugin-gradle:5.17.1"
   implementation 'org.eclipse.jgit:org.eclipse.jgit:5.4.0.201906121030-r'
   implementation 'com.netflix.nebula:gradle-ospackage-plugin:8.4.1'
   implementation 'gradle.plugin.com.google.cloud.artifactregistry:artifactregistry-gradle-plugin:2.1.1'

--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/codestyle/SpinnakerCodeStylePlugin.groovy
@@ -58,7 +58,7 @@ class SpinnakerCodeStylePlugin implements Plugin<Project> {
           @Override
           void execute(JavaExtension javaExtension) {
             javaExtension.target("src/**/*.java")
-            javaExtension.googleJavaFormat("1.8")
+            javaExtension.googleJavaFormat("1.11.0")
             javaExtension.removeUnusedImports()
             javaExtension.trimTrailingWhitespace()
             javaExtension.endWithNewline()
@@ -79,7 +79,7 @@ class SpinnakerCodeStylePlugin implements Plugin<Project> {
           spotless.kotlin(new Action<KotlinExtension>() {
             @Override
             void execute(KotlinExtension kotlinExtension) {
-              kotlinExtension.ktlint("0.37.2").userData(ktlintData)
+              kotlinExtension.ktlint("0.42.1").userData(ktlintData)
               kotlinExtension.trimTrailingWhitespace()
               kotlinExtension.endWithNewline()
             }
@@ -89,7 +89,7 @@ class SpinnakerCodeStylePlugin implements Plugin<Project> {
             @Override
             void execute(KotlinGradleExtension kotlinGradleExtension) {
               kotlinGradleExtension.target("*.gradle.kts", "**/*.gradle.kts")
-              kotlinGradleExtension.ktlint("0.37.2").userData(ktlintData)
+              kotlinGradleExtension.ktlint("0.42.1").userData(ktlintData)
               kotlinGradleExtension.trimTrailingWhitespace()
               kotlinGradleExtension.endWithNewline()
             }


### PR DESCRIPTION
While upgrading the gradle wrapper to 7.6.1 for spinnaker services, all the services (clouddriver, gate, igor, echo, front50, fiat, halyard, rosco, kayenta, orca) faced below warning related to spotlessMisc task ordering (a sample from igor):
```
> Task :spotlessMisc
Execution optimizations have been disabled for task ':spotlessMisc' to ensure correctness due to the following reasons:
  - Gradle detected a problem with the following location: '/gradle-upgrade-7.x/gradle7/igor'. Reason: Task ':spotlessMisc' uses this output of task ':spotlessJava' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
  - Gradle detected a problem with the following location: '/gradle-upgrade-7.x/gradle7/igor'. Reason: Task ':spotlessMisc' uses this output of task ':igor-web:processResources' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6.1/userguide/validation_problems.html#implicit_dependency for more details about this problem.
```
The root cause of the issue is old version of `com.diffplug.spotless:spotless-plugin-gradle:5.1.0` used by spinnaker-gradle-project `codestyle` plugin. Since this plugin is applied to all spinnaker services, fix can be applied to spinnaker-gradle-project codestyle plugin by upgrading `com.diffplug.spotless:spotless-plugin-gradle` to [5.17.1](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#5171---2021-10-26) along with it upgrading [google-java-format](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#5143---2021-08-20) to 1.11.0 and [ktlint](https://github.com/diffplug/spotless/blob/main/plugin-gradle/CHANGES.md#5143---2021-08-20) to 0.42.1