### PR TITLE
Revert "chore(deck): add yarn modules call before yarn build (#166)"

### DIFF
--- a/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
+++ b/spinnaker-extensions/src/main/kotlin/com/netflix/spinnaker/gradle/extension/SpinnakerUIExtensionPlugin.kt
@@ -47,17 +47,10 @@ class SpinnakerUIExtensionPlugin : Plugin<Project> {
       commandLine = listOf(yarnCmd)
     }
 
-    project.tasks.create("yarnModules", Exec::class.java) {
-      group = Plugins.GROUP
-      workingDir = project.projectDir
-      commandLine = listOf(yarnCmd, "modules")
-    }
-
     project.tasks.create("yarnBuild", Exec::class.java) {
       group = Plugins.GROUP
       workingDir = project.projectDir
       commandLine = listOf(yarnCmd, "build")
-      dependsOn("yarnModules")
     }
 
     project.afterEvaluate {


### PR DESCRIPTION
This reverts commit d2b3f2ea940204144f20164c0a17fb253f2f20d2.

I broke frontend plugins, no yarn modules command exists 😓  https://github.com/spinnaker/spinnaker-gradle-project/pull/166