### PR TITLE
fix(build): add mavenCentral repository to all modules to fix Spotless

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/baseproject/SpinnakerBaseProjectConventionsPlugin.groovy
@@ -20,10 +20,9 @@ class SpinnakerBaseProjectConventionsPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
       def javaVersion = Flags.targetJava17(project) ? JavaVersion.VERSION_17 : JavaVersion.VERSION_11
-
+      project.repositories.mavenCentral()
       project.plugins.withType(JavaBasePlugin) {
         project.plugins.apply(MavenPublishPlugin)
-        project.repositories.mavenCentral()
         JavaPluginConvention convention = project.convention.getPlugin(JavaPluginConvention)
         convention.sourceCompatibility = javaVersion
         convention.targetCompatibility = javaVersion


### PR DESCRIPTION
I don't know how Spotless was working previously, but >=6.0.0 changed how repositories are sourced. Modules without the `java-library` are now failing as they have no repositories defined.

By moving this call out of the if statement we add `mavenCentral` to all modules and resolve this issue.