### PR TITLE
chore(java): Add some default runtime flags for java 17

### DIFF
--- a/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
+++ b/spinnaker-project-plugin/src/main/groovy/com/netflix/spinnaker/gradle/application/SpinnakerApplicationPlugin.groovy
@@ -19,7 +19,11 @@ class SpinnakerApplicationPlugin implements Plugin<Project> {
         appConvention.applicationDistribution.from(project.file("config/${appName}.yml")) {
             into('config')
         }
-        appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom"
+        appConvention.applicationDefaultJvmArgs << "-Djava.security.egd=file:/dev/./urandom" +
+          // Required for some google SDK behavior when loading certs as part of creds
+          " --add-exports=java.base/sun.security.x509=ALL-UNNAMED" +
+          " --add-exports=java.base/sun.security.pkcs=ALL-UNNAMED" +
+          " --add-exports=java.base/sun.security.rsa=ALL-UNNAMED"
 
         project.tasks.withType(CreateStartScripts) {
             it.defaultJvmOpts = appConvention.applicationDefaultJvmArgs + ["-Dspring.config.import=optional:/opt/spinnaker/config/"]


### PR DESCRIPTION
Enables access to sun security stuff that google uses for a couple of cert loads.  Will let other places doing PKI using sun stuff work using GCS storage or similar type configs.